### PR TITLE
Merging beta 2.0.20 into Main

### DIFF
--- a/Licence
+++ b/Licence
@@ -1,19 +1,676 @@
 Copyright (c) <2021> <Ben Whitmore, ben@byteben.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/Private/Connect-Graph.ps1
+++ b/Private/Connect-Graph.ps1
@@ -1,0 +1,122 @@
+# Function to install the Microsoft Graph module and get a token
+<#
+.Synopsis
+Created on:   22/01/2024
+Created by:   Ben Whitmore
+Filename:     Connect-Graph.ps1
+
+.Description
+Function to connect to Microsoft Graph
+
+.PARAMETER LogID
+The component (script name) passed as LogID to the 'Write-Log' function. 
+This parameter is built from the line number of the call from the function up the pipeline
+
+.PARAMETER ClientID
+ClientID. If not specified, the default value is used for Microsoft Intune PoSh
+
+.PARAMETER RedirectUri
+Redirect URI. If not specified, the default value for OAuth2 is used
+
+.PARAMETER ModuleName
+Module Name to connect to Graph. If not specified, the default value is used for Microsoft.Graph
+
+.PARAMETER PackageProivder
+Package Provider. If not specified, the default value NuGet is used
+
+.PARAMETER ModuleScope
+Module Scope. If not specified, the default value is used for CurrentUser
+
+#>
+function Connect-Graph {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "The component (script name) passed as LogID to the 'Write-Log' function")]
+        [string]$LogId = $($MyInvocation.MyCommand).Name,
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "Module Name to connect to Graph. If not specified, the default value is used for Microsoft.Graph")]
+        [string]$ModuleName = 'Microsoft.Graph',
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value NuGet is used for PackageProivder")]
+        [string]$PackageProivder = 'NuGet',
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value is used for CurrentUser")]
+        [string]$ModuleScope = 'CurrentUser',
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value is used for Microsoft Intune PoSh")]
+        [string]$ClientId = 'd1ddf0e4-d672-4dae-b554-9d5bdfd93547',
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value for OAuth2 is used")]
+        [string]$RedirectUri = 'urn:ietf:wg:oauth:2.0:oob',
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "The scopes to request from the Microsoft Graph API. If not specified, the default value is used for Application.ReadWrite.All")]
+        [string]$Scopes = 'Application.ReadWrite.All'
+    )
+
+    begin {
+        Write-Log -Message 'Function: Connect-Graph was called' -LogId $LogId
+
+        if (-not (Get-PackageProvider -ListAvailable -Name $PackageProivder)) {
+
+            # Install the PackageProvider if it's not already installed
+            Write-Log -Message ("PackageProvider not found. Will install PackageProvider '{0}'" -f $PackageProivder) -LogId $LogId
+            Write-Host ("Installing PackageProivder '{0}'" -f $PackageProivder) -ForegroundColor Cyan
+    
+            try {
+                Install-PackageProvider -Name $PackageProvider -ForceBootstrap -Confirm:$false -Verbose
+            }
+            catch {
+                Write-Log -Message ("Warning: Could not install the PackageProvider '{0}'" -f $PackageProivder) -LogId $LogId -Severity 3
+                Write-Warning ("Warning: Could not install the PackageProvider '{0}'" -f $PackageProivder)
+                Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
+                Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+            }
+        }
+
+        # Check if the module is installed
+        if (-not (Get-Module -ListAvailable -Name Microsoft.Graph)) {
+
+            # Install the module if it's not already installed
+            Write-Log -Message ("Module not found. Will install module '{0}' in the scope of '{1}'" -f $ModuleName, $ModuleScope) -LogId $LogId
+            Write-Host ("Installing module '{0}' in the scope of '{1}'" -f $ModuleName, $ModuleScope) -ForegroundColor Cyan
+    
+            try {
+                Install-Module -Name $ModuleName -Scope $ModuleScope -AllowClobber -Force -Confirm:$false
+            }
+            catch {
+                Write-Log -Message ("Warning: Could not install the module '{0}'" -f $ModuleName) -LogId $LogId -Severity 3
+                Write-Warning ("Warning: Could not install the module '{0}'" -f $ModuleName)
+                Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
+                Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+            }
+        }
+        else {
+            # Module is already installed, import it
+            Write-Log -Message ("Module '{0}' is already installed" -f $ModuleName) -LogId $LogId
+            Write-Host ("Module '{0}' is already installed" -f $ModuleName) -ForegroundColor Cyan
+
+            try {
+                Write-Log -Message ("Import-Module {0}" -f $ModuleName) -LogId $LogId
+                Write-Host ("Importing Module: '{0}'" -f $ModuleName) -ForegroundColor Cyan
+                Import-Module Microsoft.Graph
+            }
+            catch {
+                Write-Log -Message ("Warning: Could not import the module '{0}'" -f $ModuleName) -LogId $LogId -Severity 3
+                Write-Warning ("Warning: Could not import the module '{0}'" -f $ModuleName)
+                Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
+                Get-ScriptEnd -Message $_.Exception.Message -LogId $LogId 
+            }
+        }
+    }
+
+    process {
+        
+        # Connect to Microsoft Graph
+        Connect-MgGraph -Scopes $scope -NoWelcome
+
+        # Check if the connection is successful
+        if (Get-MgContext) {
+            Write-Log -Message 'Connected to Microsoft Graph successfully' -LogId $LogId
+            Write-Host 'Connected to Microsoft Graph successfully'
+        }
+        else {
+            Write-Log -Message 'Failed to connect to Microsoft Graph' -LogId $LogId -Severity 3
+            Write-Host 'Failed to connect to Microsoft Graph'
+            Get-ScriptEnd -Message 'Failed to connect to Microsoft Graph' -LogId $LogId 
+        }
+    }
+}

--- a/Private/Connect-Graph.ps1
+++ b/Private/Connect-Graph.ps1
@@ -12,12 +12,6 @@ Function to connect to Microsoft Graph
 The component (script name) passed as LogID to the 'Write-Log' function. 
 This parameter is built from the line number of the call from the function up the pipeline
 
-.PARAMETER ClientID
-ClientID. If not specified, the default value is used for Microsoft Intune PoSh
-
-.PARAMETER RedirectUri
-Redirect URI. If not specified, the default value for OAuth2 is used
-
 .PARAMETER ModuleName
 Module Name to connect to Graph. If not specified, the default value is used for Microsoft.Graph
 
@@ -27,24 +21,28 @@ Package Provider. If not specified, the default value NuGet is used
 .PARAMETER ModuleScope
 Module Scope. If not specified, the default value is used for CurrentUser
 
+.PARAMETER Scopes
+The scopes to request from the Microsoft Graph API. If not specified, the default value is used for Application.ReadWrite.All
+
+.PARAMETER UseDeviceAuthentication
+This parameter will be used to determine if the device authentication flow should be used. If not specified, the default value is used for $false
+
 #>
 function Connect-Graph {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "The component (script name) passed as LogID to the 'Write-Log' function")]
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'The component (script name) passed as LogID to the "Write-Log" function')]
         [string]$LogId = $($MyInvocation.MyCommand).Name,
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "Module Name to connect to Graph. If not specified, the default value is used for Microsoft.Graph")]
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'Module Name to connect to Graph. If not specified, the default value is used for Microsoft.Graph')]
         [string]$ModuleName = 'Microsoft.Graph',
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value NuGet is used for PackageProivder")]
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'If not specified, the default value NuGet is used for PackageProivder')]
         [string]$PackageProivder = 'NuGet',
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value is used for CurrentUser")]
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'If not specified, the default value is used for CurrentUser')]
         [string]$ModuleScope = 'CurrentUser',
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value is used for Microsoft Intune PoSh")]
-        [string]$ClientId = 'd1ddf0e4-d672-4dae-b554-9d5bdfd93547',
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "If not specified, the default value for OAuth2 is used")]
-        [string]$RedirectUri = 'urn:ietf:wg:oauth:2.0:oob',
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "The scopes to request from the Microsoft Graph API. If not specified, the default value is used for Application.ReadWrite.All")]
-        [string]$Scopes = 'Application.ReadWrite.All'
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'The scopes to request from the Microsoft Graph API. If not specified, the default value is used for Application.ReadWrite.All')]
+        [string]$Scopes = 'DeviceManagementApps.ReadWrite.All',
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'This parameter will be used to determine if the device authentication flow should be used. If not specified, the default value is used for $false')]
+        [switch]$UseDeviceAuthentication = $false
     )
 
     begin {
@@ -68,7 +66,7 @@ function Connect-Graph {
         }
 
         # Check if the module is installed
-        if (-not (Get-Module -ListAvailable -Name Microsoft.Graph)) {
+        if (-not (Get-Module -ListAvailable -Name $ModuleName)) {
 
             # Install the module if it's not already installed
             Write-Log -Message ("Module not found. Will install module '{0}' in the scope of '{1}'" -f $ModuleName, $ModuleScope) -LogId $LogId
@@ -89,24 +87,41 @@ function Connect-Graph {
             Write-Log -Message ("Module '{0}' is already installed" -f $ModuleName) -LogId $LogId
             Write-Host ("Module '{0}' is already installed" -f $ModuleName) -ForegroundColor Cyan
 
-            try {
-                Write-Log -Message ("Import-Module {0}" -f $ModuleName) -LogId $LogId
-                Write-Host ("Importing Module: '{0}'" -f $ModuleName) -ForegroundColor Cyan
-                Import-Module Microsoft.Graph
-            }
-            catch {
-                Write-Log -Message ("Warning: Could not import the module '{0}'" -f $ModuleName) -LogId $LogId -Severity 3
-                Write-Warning ("Warning: Could not import the module '{0}'" -f $ModuleName)
-                Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
-                Get-ScriptEnd -Message $_.Exception.Message -LogId $LogId 
+            if (-not (Get-Module -Name $ModuleName)) {
+
+                try {
+                    Write-Log -Message ("Import-Module {0}" -f $ModuleName) -LogId $LogId
+                    Write-Host ("Importing Module: '{0}'" -f $ModuleName) -ForegroundColor Cyan
+                    Import-Module Microsoft.Graph
+                }
+                catch {
+                    Write-Log -Message ("Warning: Could not import the module '{0}'" -f $ModuleName) -LogId $LogId -Severity 3
+                    Write-Warning ("Warning: Could not import the module '{0}'" -f $ModuleName)
+                    Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
+                    Get-ScriptEnd -Message $_.Exception.Message -LogId $LogId 
+                }
+                else {
+                    Write-Log -Message ("Module '{0}' is imported into PowerShell session" -f $ModuleName) -LogId $LogId
+                    Write-Host ("Module '{0}' is imported into PowerShell session" -f $ModuleName) -ForegroundColor Cyan
+                }
             }
         }
     }
 
     process {
+
+        # Build connection splat
+        $ConnectGraphSplat = @{
+            Scopes    = $Scopes
+            NoWelcome = $true
+        }
+
+        if ($PSBoundParameters["UseDeviceAuthentication"]) {
+            $connectGraphSplat.Add('UseDeviceAuthentication', $true)
+        }
         
         # Connect to Microsoft Graph
-        Connect-MgGraph -Scopes $scope -NoWelcome
+        Connect-MgGraph $ConnectGraphSplat
 
         # Check if the connection is successful
         if (Get-MgContext) {

--- a/Private/Connect-Graph.ps1
+++ b/Private/Connect-Graph.ps1
@@ -2,7 +2,7 @@
 <#
 .Synopsis
 Created on:   22/01/2024
-Updated on:   24/04/2024
+Updated on:   24/03/2024
 Created by:   Ben Whitmore
 Filename:     Connect-Graph.ps1
 

--- a/Private/Connect-Graph.ps1
+++ b/Private/Connect-Graph.ps1
@@ -2,6 +2,7 @@
 <#
 .Synopsis
 Created on:   22/01/2024
+Updated on:   24/04/2024
 Created by:   Ben Whitmore
 Filename:     Connect-Graph.ps1
 
@@ -15,7 +16,7 @@ This parameter is built from the line number of the call from the function up th
 .PARAMETER ModuleName
 Module Name to connect to Graph. If not specified, the default value is used for Microsoft.Graph
 
-.PARAMETER PackageProivder
+.PARAMETER PackageProvider
 Package Provider. If not specified, the default value NuGet is used
 
 .PARAMETER ModuleScope
@@ -28,15 +29,15 @@ The scopes to request from the Microsoft Graph API. If not specified, the defaul
 This parameter will be used to determine if the device authentication flow should be used. If not specified, the default value is used for $false
 
 #>
-function Connect-Graph {
+function Invoke-GraphConnection {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'The component (script name) passed as LogID to the "Write-Log" function')]
         [string]$LogId = $($MyInvocation.MyCommand).Name,
         [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'Module Name to connect to Graph. If not specified, the default value is used for Microsoft.Graph')]
-        [string]$ModuleName = 'Microsoft.Graph',
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'If not specified, the default value NuGet is used for PackageProivder')]
-        [string]$PackageProivder = 'NuGet',
+        [string]$ModuleName = 'Microsoft.Graph.Devices.CorporateManagement',
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'If not specified, the default value NuGet is used for PackageProvider')]
+        [string]$PackageProvider = 'NuGet',
         [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'If not specified, the default value is used for CurrentUser')]
         [string]$ModuleScope = 'CurrentUser',
         [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'The scopes to request from the Microsoft Graph API. If not specified, the default value is used for Application.ReadWrite.All')]
@@ -48,20 +49,20 @@ function Connect-Graph {
     begin {
         Write-Log -Message 'Function: Connect-Graph was called' -LogId $LogId
 
-        if (-not (Get-PackageProvider -ListAvailable -Name $PackageProivder)) {
+        if (-not (Get-PackageProvider -ListAvailable -Name $PackageProvider)) {
 
             # Install the PackageProvider if it's not already installed
-            Write-Log -Message ("PackageProvider not found. Will install PackageProvider '{0}'" -f $PackageProivder) -LogId $LogId
-            Write-Host ("Installing PackageProivder '{0}'" -f $PackageProivder) -ForegroundColor Cyan
+            Write-Log -Message ("PackageProvider not found. Will install PackageProvider '{0}'" -f $PackageProvider) -LogId $LogId
+            Write-Host ("Installing PackageProvider '{0}'" -f $PackageProvider) -ForegroundColor Cyan
     
             try {
                 Install-PackageProvider -Name $PackageProvider -ForceBootstrap -Confirm:$false -Verbose
             }
             catch {
-                Write-Log -Message ("Warning: Could not install the PackageProvider '{0}'" -f $PackageProivder) -LogId $LogId -Severity 3
-                Write-Warning ("Warning: Could not install the PackageProvider '{0}'" -f $PackageProivder)
+                Write-Log -Message ("Warning: Could not install the PackageProvider '{0}'" -f $PackageProvider) -LogId $LogId -Severity 3
+                Write-Warning ("Warning: Could not install the PackageProvider '{0}'" -f $PackageProvider)
                 Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
-                Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+                Get-ScriptEnd -ErrorMessage $_.Exception.Message -LogId $LogId 
             }
         }
 
@@ -79,7 +80,7 @@ function Connect-Graph {
                 Write-Log -Message ("Warning: Could not install the module '{0}'" -f $ModuleName) -LogId $LogId -Severity 3
                 Write-Warning ("Warning: Could not install the module '{0}'" -f $ModuleName)
                 Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
-                Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+                Get-ScriptEnd -ErrorMessage $_.Exception.Message -LogId $LogId
             }
         }
         else {
@@ -92,18 +93,18 @@ function Connect-Graph {
                 try {
                     Write-Log -Message ("Import-Module {0}" -f $ModuleName) -LogId $LogId
                     Write-Host ("Importing Module: '{0}'" -f $ModuleName) -ForegroundColor Cyan
-                    Import-Module Microsoft.Graph
+                    Import-Module $ModuleName
                 }
                 catch {
                     Write-Log -Message ("Warning: Could not import the module '{0}'" -f $ModuleName) -LogId $LogId -Severity 3
                     Write-Warning ("Warning: Could not import the module '{0}'" -f $ModuleName)
                     Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
-                    Get-ScriptEnd -Message $_.Exception.Message -LogId $LogId 
+                    Get-ScriptEnd -ErrorMessage $_.Exception.Message -LogId $LogId 
                 }
-                else {
-                    Write-Log -Message ("Module '{0}' is imported into PowerShell session" -f $ModuleName) -LogId $LogId
-                    Write-Host ("Module '{0}' is imported into PowerShell session" -f $ModuleName) -ForegroundColor Cyan
-                }
+            }
+            else {
+                Write-Log -Message ("Module '{0}' is imported into PowerShell session" -f $ModuleName) -LogId $LogId
+                Write-Host ("Module '{0}' is imported into PowerShell session" -f $ModuleName) -ForegroundColor Cyan
             }
         }
     }
@@ -121,17 +122,44 @@ function Connect-Graph {
         }
         
         # Connect to Microsoft Graph
-        Connect-MgGraph $ConnectGraphSplat
+        try {
+            Connect-MgGraph @ConnectGraphSplat -ErrorAction Stop
+        }
+        catch {
+            Write-Warning -Message ("'{0}'" -f $_.Exception.Message)
+            Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
+            Get-ScriptEnd -ErrorMessage 'Failed to connect to Microsoft Graph' -LogId $LogId
+        }
 
         # Check if the connection is successful
-        if (Get-MgContext) {
+        $graphContext = Get-MgContext
+
+        if ($graphContext) {
+
+            #Log the connection details
             Write-Log -Message 'Connected to Microsoft Graph successfully' -LogId $LogId
-            Write-Host 'Connected to Microsoft Graph successfully'
+            Write-Log -Message ("ClientId: '{0}',TenantId: '{1}',Scopes: '{2}',AuthType: '{3}',TokenCredentialType: '{4}',Account: '{5}',ContextScope: '{6}'," -f `
+                    $graphContext.ClientId, `
+                    $graphContext.TenantId, `
+                ($graphContext.Scopes -join ", "), `
+                    $graphContext.AuthType, `
+                    $graphContext.TokenCredentialType, `
+                    $graphContext.Account, `
+                    $graphContext.ContextScope) -LogId $LogId
+
+            # Write the connection details to the console
+            Write-Host 'Connected to Microsoft Graph successfully' -ForegroundColor Cyan
+            Write-Host ("ClientId: '{0}',TenantId: '{1}',Scopes: '{2}',AuthType: '{3}',TokenCredentialType: '{4}',Account: '{5}',ContextScope: '{6}'," -f `
+                    $graphContext.ClientId, `
+                    $graphContext.TenantId, `
+                ($graphContext.Scopes -join ", "), `
+                    $graphContext.AuthType, `
+                    $graphContext.TokenCredentialType, `
+                    $graphContext.Account, `
+                    $graphContext.ContextScope) -ForegroundColor Green
         }
         else {
-            Write-Log -Message 'Failed to connect to Microsoft Graph' -LogId $LogId -Severity 3
-            Write-Host 'Failed to connect to Microsoft Graph'
-            Get-ScriptEnd -Message 'Failed to connect to Microsoft Graph' -LogId $LogId 
+            Get-ScriptEnd -ErrorMessage 'Failed to connect to Microsoft Graph' -LogId $LogId 
         }
     }
 }

--- a/Private/Connect-SiteServer.ps1
+++ b/Private/Connect-SiteServer.ps1
@@ -1,6 +1,7 @@
 <#
 .Synopsis
 Created on:   26/10/2023
+Updated on:   20/01/2024
 Created by:   Ben Whitmore
 Filename:     Connect-SiteServer.ps1
 
@@ -69,21 +70,21 @@ function Connect-SiteServer {
         # Connect to the site drive if it is not already present
         try {
             if (!($SiteCode -eq ( Get-PSDrive -ErrorAction SilentlyContinue | Where-Object { $_.Provider -like "*CMSite*" }).Name) ) {
-                Write-Log -Message ("No PSDrive found for '{0}' in PSProvider CMSite for Root '{1}'" -f $SiteCode, $ProviderMachineName) -Severity 3
+                Write-Log -Message ("No PSDrive found for '{0}' in PSProvider CMSite for Root '{1}'" -f $SiteCode, $ProviderMachineName) -LogId $LogId -Severity 3
                 Write-Warning ("No PSDrive found for '{0}' in PSProvider CMSite for Root '{1}'. Did you specify the correct Site Code?" -f $SiteCode, $ProviderMachineName)
                 Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
 
             }
             else {
-                Write-Log -Message ("Connected to PSDrive '{0}'" -f $SiteCode)
+                Write-Log -Message ("Connected to PSDrive '{0}'" -f $SiteCode) -LogId $LogId
                 Write-Host ("Connected to PSDrive '{0}'" -f $SiteCode) -ForegroundColor Green 
                 Set-Location "$($SiteCode):\"
             }
         }
         catch {
-            Write-Log -Message ("Warning: Could not connect to the specified provider '{0}' at site '{1}'" -f $ProviderMachineName, $SiteCode) -Severity 3
+            Write-Log -Message ("Warning: Could not connect to the specified provider '{0}' at site '{1}'" -f $ProviderMachineName, $SiteCode) -LogId $LogId -Severity 3
             Write-Warning ("Warning: Could not connect to the specified provider '{0}' at site '{1}'" -f $ProviderMachineName, $SiteCode)
-            Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+            Get-ScriptEnd -Message $_.Exception.Message -LogId $LogId 
         }
     }
 }

--- a/Private/Connect-SiteServer.ps1
+++ b/Private/Connect-SiteServer.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   26/10/2023
-Updated on:   20/01/2024
+Updated on:   17/02/2024
 Created by:   Ben Whitmore
 Filename:     Connect-SiteServer.ps1
 
@@ -52,7 +52,7 @@ function Connect-SiteServer {
             Write-Log -Message "Warning: Could not import the ConfigurationManager.psd1 Module"
             Write-Warning "Warning: Could not import the 'ConfigurationManager.psd1' module"
             Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
-            Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+            Get-ScriptEnd -LogId $LogId -ErrorMessage $_.Exception.Message
     }
 
         # Check the SMS Provider is valid
@@ -60,7 +60,7 @@ function Connect-SiteServer {
             Write-Log -Message ("Could not connect to the Provider '{0}'" -f $ProviderMachineName) -Severity 3
             Write-Warning ("Could not connect to the Provider '{0}' `nDid you specify the correct Site System?" -f $ProviderMachineName)
             Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
-            Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+            Get-ScriptEnd -LogId $LogId -ErrorMessage $_.Exception.Message
         }
         else {
             Write-Log -Message ("Connected to provider {0} at site '{1}'" -f $ProviderMachineName, $SiteCode )
@@ -72,7 +72,7 @@ function Connect-SiteServer {
             if (!($SiteCode -eq ( Get-PSDrive -ErrorAction SilentlyContinue | Where-Object { $_.Provider -like "*CMSite*" }).Name) ) {
                 Write-Log -Message ("No PSDrive found for '{0}' in PSProvider CMSite for Root '{1}'" -f $SiteCode, $ProviderMachineName) -LogId $LogId -Severity 3
                 Write-Warning ("No PSDrive found for '{0}' in PSProvider CMSite for Root '{1}'. Did you specify the correct Site Code?" -f $SiteCode, $ProviderMachineName)
-                Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
+                Get-ScriptEnd -LogId $LogId -ErrorMessage $_.Exception.Message
 
             }
             else {
@@ -84,7 +84,7 @@ function Connect-SiteServer {
         catch {
             Write-Log -Message ("Warning: Could not connect to the specified provider '{0}' at site '{1}'" -f $ProviderMachineName, $SiteCode) -LogId $LogId -Severity 3
             Write-Warning ("Warning: Could not connect to the specified provider '{0}' at site '{1}'" -f $ProviderMachineName, $SiteCode)
-            Get-ScriptEnd -Message $_.Exception.Message -LogId $LogId 
+            Get-ScriptEnd -ErrorMessage $_.Exception.Message -LogId $LogId 
         }
     }
 }

--- a/Private/Export-CsvDetails.ps1
+++ b/Private/Export-CsvDetails.ps1
@@ -1,6 +1,7 @@
 <#
 .Synopsis
 Created on:   05/11/23
+Updated on:   16/12/23
 Created by:   Ben Whitmore
 Filename:     Export-Csv.ps1
 
@@ -36,25 +37,39 @@ function Export-CsvDetails {
 
     begin {
 
+        # Specify CSV archive folder name
+        $archiveFolder = 'Old'
+
         # Log the export
         Write-Log -Message ("Exporting '{0}' information to '{1}\{0}.csv'" -f $Name, $Path) -LogId $LogId
         Write-Host ("Exporting '{0}' information to '{1}\{0}.csv'" -f $Name, $Path) -ForegroundColor Cyan
 
         # Build path string
-        $Path = Join-Path -Path $Path -ChildPath ("{0}.csv" -f $Name)
+        $fullPath = Join-Path -Path $Path -ChildPath ("{0}.csv" -f $Name)
+        $archivePath = Join-Path -Path $Path -ChildPath $archiveFolder
 
         # Rollover the csv if it already exists from a previous run
-        if (Test-Path -Path $Path) {
-            Write-Log -Message ("'{0}\{1}.csv' already exists, rolling over csv" -f $Path, $Name) -LogId $LogId -Severity 2
-            Write-Host ("'{0}' already exists, rolling over csv" -f $Path) -ForegroundColor Yellow
+        if (Test-Path -Path $fullPath) {
+            Write-Log -Message ("'{0}' already exists, rolling over csv" -f $fullPath) -LogId $LogId -Severity 2
+            Write-Host ("'{0}' already exists, rolling over csv" -f $fullPath) -ForegroundColor Yellow
             $date = Get-Date -Format 'yyyyMMddHHmmss'
-            $pathRename = $Path -replace '.csv', ''
+            $pathRename = $fullPath -replace '.csv', ''
 
             # Attempt to rename the file, if it fails continue but the file will be overwritten
             try {
-                Rename-Item -Path $Path -NewName ("{0}_{1}.csv" -f $pathRename, $date)
-                Write-Log -Message ("Previous Csv rolled over to '{0}_{1}.csv'" -f $pathRename, $date) -LogId $LogId
-                Write-Host ("Previous Csv rolled over to '{0}_{1}.csv'" -f $pathRename, $date) -ForegroundColor Green
+                $newPath = ("{0}_{1}.csv" -f $pathRename, $date)
+                Rename-Item -Path $fullPath -NewName $newPath
+                
+                # Create the archive folder if it does not exist
+                if (-not (Test-Path -Path $archivePath)){
+                    New-FolderToCreate -Root $Path -FolderNames $archiveFolder
+                }
+
+                # Move the old CSV into the archive folder
+                Move-Item -Path $newPath -Destination $archivePath -Force
+
+                Write-Log -Message ("Previous Csv rolled over to '{0}\{1}_{2}.csv'" -f $archivePath, $pathRename, $date) -LogId $LogId
+                Write-Host ("Previous Csv rolled over to '{0}\{1}_{2}.csv'" -f $archivePath, $pathRename, $date) -ForegroundColor Green
             }
             catch {
                 Write-Log -Message ("Failed to rollover '{0}'. Csv will be overwritten." -f $Path) -LogId $LogId -Severity 3
@@ -70,20 +85,20 @@ function Export-CsvDetails {
             try {
 
                 # Check if the file already exists to handle the header correctly
-                if (-not (Test-Path -Path $Path) ) {
+                if (-not (Test-Path -Path $fullPath) ) {
 
                     # Include headers if the file doesn't exist
-                    $object | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath $Path
+                    $object | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath $fullPath
                 }
                 else {
 
                     # If the file exists, skip the header line
-                    $object | ConvertTo-Csv -NoTypeInformation | Select-Object -Skip 1 | Out-File -FilePath $Path -Append
+                    $object | ConvertTo-Csv -NoTypeInformation | Select-Object -Skip 1 | Out-File -FilePath $fullPath -Append
                 }
             }
             catch {
-                Write-Log -Message ("Failed to export '{0}' information to '{1}'" -f $Type, $Path) -LogId $LogId -Severity 3
-                Write-Host ("Failed to export '{0}' information to '{1}'" -f $Type, $Path) -ForegroundColor Red
+                Write-Log -Message ("Failed to export '{0}' information to '{1}'" -f $Type, $fullPath) -LogId $LogId -Severity 3
+                Write-Host ("Failed to export '{0}' information to '{1}'" -f $Type, $fullPath) -ForegroundColor Red
                 Write-Log -Message ("'{0}'" -f $_.Exception.Message) -LogId $LogId -Severity 3
                 throw
             }

--- a/Private/Export-CsvDetails.ps1
+++ b/Private/Export-CsvDetails.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   05/11/23
-Updated on:   16/12/23
+Updated on:   17/02/24
 Created by:   Ben Whitmore
 Filename:     Export-Csv.ps1
 
@@ -68,8 +68,8 @@ function Export-CsvDetails {
                 # Move the old CSV into the archive folder
                 Move-Item -Path $newPath -Destination $archivePath -Force
 
-                Write-Log -Message ("Previous Csv rolled over to '{0}\{1}_{2}.csv'" -f $archivePath, $pathRename, $date) -LogId $LogId
-                Write-Host ("Previous Csv rolled over to '{0}\{1}_{2}.csv'" -f $archivePath, $pathRename, $date) -ForegroundColor Green
+                Write-Log -Message ("Previous Csv rolled over to '{0}\{1}_{2}.csv'" -f $archivePath, $Name, $date) -LogId $LogId
+                Write-Host ("Previous Csv rolled over to '{0}\{1}_{2}.csv'" -f $archivePath, $Name, $date) -ForegroundColor Green
             }
             catch {
                 Write-Log -Message ("Failed to rollover '{0}'. Csv will be overwritten." -f $Path) -LogId $LogId -Severity 3

--- a/Private/Get-AppInfo.ps1
+++ b/Private/Get-AppInfo.ps1
@@ -32,6 +32,7 @@ function Get-AppInfo {
 
         # Create a counter
         $i = 0
+
     }
     process {
     
@@ -110,7 +111,7 @@ function Get-AppInfo {
                 Write-Warning -Message ("Could not get application information for '{0}'" -f $application.LocalizedDisplayName)
                 Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
             }
-            return $applicationTypes
         }
+        return $applicationTypes
     }
 }

--- a/Private/Get-AppInfo.ps1
+++ b/Private/Get-AppInfo.ps1
@@ -1,6 +1,7 @@
 <#
 .Synopsis
 Created on:   28/10/2023
+Update on:    20/01/2024
 Created by:   Ben Whitmore
 Filename:     Get-AppInfo.ps1
 
@@ -83,7 +84,7 @@ function Get-AppInfo {
                 # Add IconData to last column for easy reading
                 $applicationObject | Add-Member NoteProperty -Name IconData -Value $xmlContent.AppMgmtDigest.Resources.Icon.Data
                 
-                Write-Log -Message ("Id = '{0}', LogicalName = '{1}', Name = '{2}',Description = '{3}', Publisher = '{4}', Version = '{5}', ReleaseDate = '{6}', InfoUrl = '{7}', Tags = '{8}', TotalDeploymentTypes = '{9}', IconId = '{10}', IconPath = '{11}', IconData '{12}'" -f `
+                Write-Log -Message ("Id = '{0}', LogicalName = '{1}', Name = '{2}',Description = '{3}', Publisher = '{4}', Version = '{5}', ReleaseDate = '{6}', InfoUrl = '{7}', Tags = '{8}', TotalDeploymentTypes = '{9}', IconId = '{10}', IconPath = '{11}'" -f `
                         $application.Id, `
                         $xmlContent.AppMgmtDigest.Application.LogicalName, `
                         $xmlContent.AppMgmtDigest.Application.title.'#text', `
@@ -95,8 +96,7 @@ function Get-AppInfo {
                         $xmlContent.AppMgmtDigest.Application.DisplayInfo.Tags.Tag, `
                         $totalDeploymentTypes, `
                         $xmlContent.AppMgmtDigest.Resources.Icon.Id, `
-                        $iconPath, `
-                        $xmlContent.AppMgmtDigest.Resources.Icon.Data) -LogId $LogId
+                        $iconPath) -LogId $LogId
 
                 # Output the application object but substitue the base64 icon data for readability
                 $applicationObjectOutput = $applicationObject | Select-Object -Property Id, LogicalName, Name, Description, Publisher, Version, ReleaseDate, InfoUrl, Tags, TotalDeploymentTypes, IconId, IconPath

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   28/10/2023
-Update on:    13/01/2024
+Update on:    17/02/2024
 Created by:   Ben Whitmore
 Filename:     Get-DeploymentTypeInfo.ps1
 
@@ -178,11 +178,24 @@ function Get-DeploymentTypeInfo {
                             try {
                                 $detectionTypeMethodBody | Out-File -FilePath $detectionMethodFile -Force -Encoding UTF8
                                 Write-Log -Message ("Detection method XML saved to file '{0}'" -f $detectionMethodFile) -LogId $LogId
-                                Write-Host ("Detection method XML saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Green
+                                Write-Host ("`Detection method XML saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Cyan
                             }
                             catch {
                                 Write-Log -Message ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -LogId $LogId -Severity 2
                                 Write-Host ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -ForegroundColor Yellow
+                            }
+
+                            # Attempt to extract the local detection methods from the XML. We will ignore any 'or' operators as these are not supported in Intune
+                            if (Test-Path -Path $detectionMethodFile) {
+                                $localDetectionMethods = Get-DetectionMethod -LogId $LogId -XMLObject $detectionTypeMethodBody
+                                Write-Log -Message 'Local Detection Methods extracted from XML' -LogId $LogId
+                                Write-Host "`nLocal Detection Methods extracted from XML" -ForegroundColor Cyan
+                                Write-Log -Message ("{0}" -f $localDetectionMethods) -LogId $LogId
+                                Write-Host ("{0}" -f $localDetectionMethods) -ForegroundColor Green
+                            }
+                            else {
+                                Write-Log -Message ("There was an error getting the local detection methods for deployment type '{0}' from the XML" -f $detectionMethodFile) -LogId $LogId -Severity 3
+                                Write-Host ("There was an error getting the local detection methods for deployment type '{0}' from the XML" -f $detectionMethodFile) -ForegroundColor red
                             }
                         }
                     }
@@ -218,7 +231,8 @@ function Get-DeploymentTypeInfo {
                             $detectionMethodFile) -LogId $LogId
 
                     # Output the deployment type object
-                    Write-Host "`n$deploymentObject`n" -ForegroundColor Green
+                    Write-Host "`nDeplopymentType Details extracted" -ForegroundColor Cyan
+                    Write-Host "$deploymentObject`n" -ForegroundColor Green
 
                     # Add the deployment type object to the array
                     $deploymentTypes += $deploymentObject          

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -164,8 +164,8 @@ function Get-DeploymentTypeInfo {
                                 }
                             }
                             else {
-                                Write-Log -Message ("Could not get ScriptBody encoded base64 value for deploymenttype '{0}'" -f $object.Title.InnerText) -LogId $LogId -Severity 2
-                                Write-Host ("Could not get ScriptBody encoded base64 value for deploymenttype '{0}'" -f $object.Title.InnerText) -ForegroundColor Yellow
+                                Write-Log -Message ("Could not get ScriptBody encoded base64 value for deployment type '{0}'" -f $object.Title.InnerText) -LogId $LogId -Severity 2
+                                Write-Host ("Could not get ScriptBody encoded base64 value for deployment type '{0}'" -f $object.Title.InnerText) -ForegroundColor Yellow
                             }
                         }
                         'Local' {
@@ -177,8 +177,8 @@ function Get-DeploymentTypeInfo {
 
                             try {
                                 $detectionTypeMethodBody | Out-File -FilePath $detectionMethodFile -Force -Encoding UTF8
-                                Write-Log -Message ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -LogId $LogId
-                                Write-Host ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Green
+                                Write-Log -Message ("Detection method XML saved to file '{0}'" -f $detectionMethodFile) -LogId $LogId
+                                Write-Host ("Detection method XML saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Green
                             }
                             catch {
                                 Write-Log -Message ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -LogId $LogId -Severity 2

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -142,6 +142,8 @@ function Get-DeploymentTypeInfo {
                                 $extractedContent = $matchSigned.Groups[1].Value
 
                                 # Decode the Base64 string
+                                #$Encoding = [System.Text.Encoding]::GetEncoding('windows-1252')
+                                #$scriptContent = $Encoding.GetString([System.Convert]::FromBase64String($extractedContent))
                                 $scriptContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($extractedContent))
 
                                 # We need to trim the script to honor digital signatures

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -156,15 +156,15 @@ function Get-DeploymentTypeInfo {
                                 try {
                                     $finalScriptContent | Out-File -FilePath $detectionMethodFile -Force -Encoding UTF8
                                     Write-Log -Message ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -LogId $LogId
-                                    Write-Host ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Yellow
+                                    Write-Host ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Green
                                 }
                                 catch {
-                                    Write-Log -Message ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -LogId $LogId
+                                    Write-Log -Message ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -LogId $LogId -Severity 2
                                     Write-Host ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -ForegroundColor Yellow
                                 }
                             }
                             else {
-                                Write-Log -Message ("Could not get ScriptBody encoded base64 value for deploymenttype '{0}'" -f $object.Title.InnerText)  -LogId $LogId
+                                Write-Log -Message ("Could not get ScriptBody encoded base64 value for deploymenttype '{0}'" -f $object.Title.InnerText) -LogId $LogId -Severity 2
                                 Write-Host ("Could not get ScriptBody encoded base64 value for deploymenttype '{0}'" -f $object.Title.InnerText) -ForegroundColor Yellow
                             }
                         }
@@ -178,10 +178,10 @@ function Get-DeploymentTypeInfo {
                             try {
                                 $detectionTypeMethodBody | Out-File -FilePath $detectionMethodFile -Force -Encoding UTF8
                                 Write-Log -Message ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -LogId $LogId
-                                Write-Host ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Yellow
+                                Write-Host ("Detection method script saved to file '{0}'" -f $detectionMethodFile) -ForegroundColor Green
                             }
                             catch {
-                                Write-Log -Message ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -LogId $LogId
+                                Write-Log -Message ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -LogId $LogId -Severity 2
                                 Write-Host ("Could not write detection method to file '{0}'" -f $detectionMethodFile) -ForegroundColor Yellow
                             }
                         }

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -144,8 +144,15 @@ function Get-DeploymentTypeInfo {
                                 # Decode the Base64 string
                                 $scriptContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($extractedContent))
 
+                                # We need to trim the script to honor digital signatures
+                                # Split the original string into lines
+                                $lines = $scriptContent -split "`n"
+
+                                # Remove the last line because the xml adds padding before the encoded string
+                                $lines = $lines[0..($lines.Count - 2)]
+
                                 # Join the lines back into a single string
-                                $finalScriptContent = $scriptContent
+                                $finalScriptContent = $lines -join "`n"
                             }
                             else {
                                 

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   28/10/2023
-Update on:    16/12/2023
+Update on:    13/01/2024
 Created by:   Ben Whitmore
 Filename:     Get-DeploymentTypeInfo.ps1
 

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -199,11 +199,22 @@ function Get-DeploymentTypeInfo {
 
                             # Attempt to extract the local detection methods from the XML. We will ignore any 'or' operators as these are not supported in Intune
                             if (Test-Path -Path $detectionMethodFile) {
-                                $localDetectionMethods = Get-LocalDetectionMethods -LogId $LogId -XMLObject $detectionTypeMethodBody
-                                Write-Log -Message 'Local Detection Methods extracted from XML' -LogId $LogId
-                                Write-Host "`nLocal Detection Methods extracted from XML" -ForegroundColor Cyan
-                                Write-Log -Message ("{0}" -f $localDetectionMethods) -LogId $LogId
-                                Write-Host ("{0}" -f $localDetectionMethods) -ForegroundColor Green
+                                $localDetectionMethods = Get-DetectionMethod -LogId $LogId -XMLObject $detectionTypeMethodBody
+                                
+                                if ($localDetectionMethods.Count -gt 0) {
+
+                                    Write-Log -Message 'Local Detection Methods extracted from XML' -LogId $LogId
+                                    Write-Host "`nLocal Detection Methods extracted from XML" -ForegroundColor Cyan
+
+                                    foreach ($method in $localDetectionMethods) {
+                                        Write-Log -Message ("{0}" -f $method) -LogId $LogId
+                                        Write-Host ("{0}" -f $method) -ForegroundColor Green
+                                    }
+                                }
+                                else {
+                                    Write-Log -Message ("There was an error getting the local detection methods for deployment type '{0}' from the XML" -f $detectionMethodFile) -LogId $LogId -Severity 3
+                                    Write-Host ("There was an error getting the local detection methods for deployment type '{0}' from the XML" -f $detectionMethodFile) -ForegroundColor Red
+                                }
                             }
                             else {
                                 Write-Log -Message ("There was an error getting the local detection methods for deployment type '{0}' from the XML" -f $detectionMethodFile) -LogId $LogId -Severity 3

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -1,6 +1,7 @@
 <#
 .Synopsis
 Created on:   28/10/2023
+Update on:    16/12/2023
 Created by:   Ben Whitmore
 Filename:     Get-DeploymentTypeInfo.ps1
 
@@ -76,9 +77,10 @@ function Get-DeploymentTypeInfo {
                     $deploymentObject | Add-Member NoteProperty -Name UninstallCommandLine -Value $Object.Installer.CustomData.UninstallCommandLine
                     $deploymentObject | Add-Member NoteProperty -Name ExecuteTime -Value $Object.Installer.CustomData.ExecuteTime
                     $deploymentObject | Add-Member NoteProperty -Name MaxExecuteTime -Value $Object.Installer.CustomData.MaxExecuteTime
-                
+                    $deploymentObject | Add-Member NoteProperty -Name DetectionProvider -Value $Object.Installer.DetectAction.Provider
+
                     Write-Log -Message ("Application_Id = '{0}', Application_Name = '{1}', Application_LogicalName = '{2}', LogicalName = '{3}', Name = '{4}', Technology = '{5}', ExecutionContext = '{6}', InstallContext = '{7}', `
-                 InstallCommandLine = '{8}', UninstallSetting = '{9}', UninstallContent = '{10}', UninstallCommandLine = '{11}', ExecuteTime = '{12}', MaxExecuteTime = '{13}'" -f `
+                 InstallCommandLine = '{8}', UninstallSetting = '{9}', UninstallContent = '{10}', UninstallCommandLine = '{11}', ExecuteTime = '{12}', MaxExecuteTime = '{13}', DetectionProvider = '{14}'" -f `
                             $ApplicationId, `
                             $xmlContent.AppMgmtDigest.Application.title.'#text', `
                             $xmlContent.AppMgmtDigest.Application.LogicalName, `
@@ -92,7 +94,8 @@ function Get-DeploymentTypeInfo {
                             $uninstallLocation, `
                             $object.Installer.CustomData.UninstallCommandLine, `
                             $object.Installer.CustomData.ExecuteTime, `
-                            $object.Installer.CustomData.MaxExecuteTime) -LogId $LogId
+                            $object.Installer.CustomData.MaxExecuteTime, `
+                            $object.Installer.DetectAction.Provider) -LogId $LogId
 
                     # Output the deployment type object
                     Write-Host "`n$deploymentObject`n" -ForegroundColor Green

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -156,7 +156,7 @@ function Get-DeploymentTypeInfo {
                             }
                             else {
                                 
-                                # Join the lines back into a single string
+                                # No need to deal with encoding, just pass the script body to the final object for saving
                                 $finalScriptContent = $detectionTypeScriptBody
                             }
   

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -76,6 +76,14 @@ function Get-DeploymentTypeInfo {
                     # Create the Detection Methods folder
                     New-FolderToCreate -Root "$workingFolder_Root\DetectionMethods" -FolderNames $detectionMethodsFolderPath
 
+                    # Remove existing files from the Detection Methods folder to avoid ambiguity on import
+                    $existingFiles = [System.IO.Directory]::GetFiles($detectionMethodsFolder)
+                    
+                    foreach ($file in $existingFiles) {
+                        Write-Log -Message ("Removing existing file '{0}'" -f $file) -LogId $LogId
+                        [System.IO.File]::Delete($file) 
+                    }
+
                     # Create a new custom hashtable to store Deployment type details
                     $deploymentObject = [PSCustomObject]@{}
 
@@ -107,7 +115,7 @@ function Get-DeploymentTypeInfo {
 
                             # Write the detection method to file
                             $detectionMethodFile = Join-Path -Path $detectionMethodsFolder -ChildPath 'DetectionScript.xml'
-                            $detectionTypeScriptBody| Out-File -FilePath $detectionMethodFile -Force
+                            $detectionTypeScriptBody | Out-File -FilePath $detectionMethodFile -Force
                         }
                         'Local' {
                             $detectionTypeExecutionContext = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ExecutionContext' }).InnerText

--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -105,6 +105,7 @@ function Get-DeploymentTypeInfo {
                     $deploymentObject | Add-Member NoteProperty -Name DetectionProvider -Value $object.Installer.DetectAction.Provider
                     
                     # Add detection method details to the PSCustomObject
+
                     Switch ($object.Installer.DetectAction.Provider) {
 
                         'Script' {
@@ -113,9 +114,26 @@ function Get-DeploymentTypeInfo {
                             $detectionTypeExecutionContext = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ExecutionContext' }).InnerText
                             $detectionTypeScriptType = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ScriptType' }).InnerText
 
+                            # ScriptType
+                            # 0 = PowerShell
+                            # 1 = VBScript
+                            # 2 = JavaScript
+
+                            Switch ($detectionTypeScriptType) {
+                                '0' {
+                                    $detectionTypeScriptFileExtension = '.ps1'
+                                }
+                                '1' {
+                                    $detectionTypeScriptFileExtension = '.vbs'
+                                }
+                                '2' {
+                                    $detectionTypeScriptFileExtension = '.js'
+                                }
+                            }
+
                             # Write the detection method to file
-                            $detectionMethodFile = Join-Path -Path $detectionMethodsFolder -ChildPath 'DetectionScript.xml'
-                            $detectionTypeScriptBody | Out-File -FilePath $detectionMethodFile -Force
+                            $detectionMethodFile = Join-Path -Path $detectionMethodsFolder -ChildPath "DetectionScript$detectionTypeScriptFileExtension"
+                            $detectionTypeScriptBody | Out-File -FilePath $detectionMethodFile -Force -Encoding UTF8
                         }
                         'Local' {
                             $detectionTypeExecutionContext = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ExecutionContext' }).InnerText
@@ -123,7 +141,7 @@ function Get-DeploymentTypeInfo {
 
                             # Write the detection method to file
                             $detectionMethodFile = Join-Path -Path $detectionMethodsFolder -ChildPath 'MethodBody.xml'
-                            $detectionTypeMethodBody | Out-File -FilePath $detectionMethodFile -Force
+                            $detectionTypeMethodBody | Out-File -FilePath $detectionMethodFile -Force -Encoding UTF8
                         }
                     }
 

--- a/Private/Get-InstallCommand.ps1
+++ b/Private/Get-InstallCommand.ps1
@@ -1,6 +1,7 @@
 <#
 .Synopsis
 Created on:   11/11/2023
+Updated on:   16/12/2023
 Created by:   Ben Whitmore
 Filename:     Get-InstallCommand.ps1
 
@@ -24,7 +25,7 @@ function Get-InstallCommand {
         [string]$LogId = $($MyInvocation.MyCommand).Name,
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0, HelpMessage = 'The setup file to be used for packaging. Normally the .msi, .exe or .ps1 file used to install the application')]
         [string]$InstallTech,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $true, Position = 1, HelpMessage = 'The setup file to be used for packaging. Normally the .msi, .exe or .ps1 file used to install the application')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 1, HelpMessage = 'The setup file to be used for packaging. Normally the .msi, .exe or .ps1 file used to install the application')]
         [string]$SetupFile
 
     )
@@ -37,9 +38,9 @@ function Get-InstallCommand {
 
         # Build the command to be used with the Win32 Content Prep Tool
         $right = ($SetupFile -split "$InstallTech")[0]
-        $right = ($right -Split " ")[-1]
-        $filename = $right.TrimStart("\", ".", "`"")
-        $command = $filename + $InstallTech
+        $rightMod = ($right -split '["'']')[-1]
+        $fileName = $rightMod.TrimStart("\", ".", "`"", "'", " ")
+        $command = $fileName + $InstallTech
 
         # Verbose and log the result
         Write-Log -Message "Extracting the SetupFile Name for the Microsoft Win32 Content Prep Tool from the Install Command..." -LogId $LogId

--- a/Private/Get-LocalDetectionMethods.ps1
+++ b/Private/Get-LocalDetectionMethods.ps1
@@ -20,7 +20,7 @@ function Get-DetectionMethod {
     param (
         [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "The component (script name) passed as LogID to the 'Write-Log' function")]
         [string]$LogId = $($MyInvocation.MyCommand).Name,
-        [Parameter(Mandatory = $true, ValueFromPipeline = $false, Position = 0, HelpMessage = 'The id of the application(s) to get information for')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $false, Position = 0, HelpMessage = 'The local detection methods XML content')]
         [object]$XMLObject
     )
     begin {

--- a/Private/Get-LocalDetectionMethods.ps1
+++ b/Private/Get-LocalDetectionMethods.ps1
@@ -34,7 +34,7 @@ function Get-DetectionMethod {
     process {
         # Create an empty array to store the settings
         $settings = @()
-        
+
         # Create a helper function to iterate through the XML nodes and find SettingReferences
         function Find-SettingReferences {
             param (

--- a/Private/Get-LocalDetectionMethods.ps1
+++ b/Private/Get-LocalDetectionMethods.ps1
@@ -1,0 +1,78 @@
+<#
+.Synopsis
+Created on:   17/02/2024
+Update on:    17/02/2024
+Created by:   Ben Whitmore
+Filename:     Get-LocalDetectionMethods.ps1
+
+.Description
+Function to get the local detection methods from the detection methods xml object
+
+.PARAMETER LogId
+The component (script name) passed as LogID to the 'Write-Log' function. 
+This parameter is built from the line number of the call from the function up the
+
+.PARAMETER XMLContent
+The XML content object to extract the detection methods from
+#>
+function Get-DetectionMethod {
+    param (
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "The component (script name) passed as LogID to the 'Write-Log' function")]
+        [string]$LogId = $($MyInvocation.MyCommand).Name,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $false, Position = 0, HelpMessage = 'The id of the application(s) to get information for')]
+        [object]$XMLObject
+    )
+    begin {
+
+        #  Load XML from a file or a variable
+        [xml]$xmlDocument = $XMLObject
+        
+    }
+    process {
+
+        # Create an array to hold the settings objects
+        $settings = @()
+
+        # Extract SimpleSetting elements
+        $XmlDocument.EnhancedDetectionMethod.Settings.SimpleSetting | ForEach-Object {
+            $simpleSetting = @{
+                Type        = "SimpleSetting"
+                LogicalName = $_.LogicalName
+                DataType    = $_.DataType
+                Is64Bit     = $_.RegistryDiscoverySource.Is64Bit
+                Depth       = $_.RegistryDiscoverySource.Depth
+                Hive        = $_.RegistryDiscoverySource.Hive
+                Key         = $_.RegistryDiscoverySource.Key
+                ValueName   = $_.RegistryDiscoverySource.ValueName
+            }
+            $settings += New-Object PSObject -Property $simpleSetting
+        }
+
+        # Extract File elements
+        $XmlDocument.EnhancedDetectionMethod.Settings.File | ForEach-Object {
+            $file = @{
+                Type        = "File"
+                LogicalName = $_.LogicalName
+                Is64Bit     = $_.Is64Bit
+                Path        = $_.Path
+                Filter      = $_.Filter
+            }
+            $settings += New-Object PSObject -Property $file
+        }
+
+        # Extract MSI elements
+        $XmlDocument.EnhancedDetectionMethod.Settings.MSI | ForEach-Object {
+            $msi = @{
+                Type        = "MSI"
+                LogicalName = $_.LogicalName
+                ProductCode = $_.ProductCode
+            }
+            $settings += New-Object PSObject -Property $msi
+        }
+
+        return $settings
+    }
+}
+# Extract the elements into a PowerShell object
+$detectionObject = Get-DetectionMethod -XmlObject $xmlObject
+$detectionObject

--- a/Private/Get-LocalDetectionMethods.ps1
+++ b/Private/Get-LocalDetectionMethods.ps1
@@ -73,6 +73,3 @@ function Get-DetectionMethod {
         return $settings
     }
 }
-# Extract the elements into a PowerShell object
-$detectionObject = Get-DetectionMethod -XmlObject $xmlObject
-$detectionObject

--- a/Private/Get-ScriptEnd.ps1
+++ b/Private/Get-ScriptEnd.ps1
@@ -1,6 +1,7 @@
 <#
 .Synopsis
 Created on:   21/10/2023
+Updated on:   24/04/2024
 Created by:   Ben Whitmore
 Filename:     Get-ScriptEnd.ps1
 
@@ -29,7 +30,7 @@ function Get-ScriptEnd {
         }
     } 
     end {
-        Set-Location -Path $ScriptRoot
+        Set-Location -Path $PSScriptRoot
         Write-Host ''
         Write-Log -Message "## The Win32AppMigrationTool Script has Finished ##" -LogId $LogId
         Write-Host '## The Win32AppMigrationTool Script has Finished ##'

--- a/Private/New-IntuneDetection.ps1
+++ b/Private/New-IntuneDetection.ps1
@@ -74,7 +74,7 @@ function New-IntuneDetectionMethod {
                         return $processedObject
                     }
                     else {
-                        
+
                         # Return the object as is if it's not an array or a custom object
                         return $object  
                     }
@@ -98,7 +98,7 @@ function New-IntuneDetectionMethod {
                 [string]$detectionType,
                 [string]$detectionValue
             )
-
+            
             # Prepare 64bit check
             if ($is64Bit -eq 'true') {
                 $check32BitOn64System = [bool]$false
@@ -330,7 +330,7 @@ function New-IntuneDetectionMethod {
                                 $regPath = Join-Path -Path $setting.Hive -ChildPath $setting.Key -ErrorAction SilentlyContinue
 
                                 $jsonArray += Add-SimpleSetting `
-                                    -is64Bit $is64Bit `
+                                    -is64Bit $setting.is64Bit `
                                     -keyPath $regPath `
                                     -valueName $setting.ValueName `
                                     -operator $setting.Rules_Operator `
@@ -340,7 +340,7 @@ function New-IntuneDetectionMethod {
                             'File' {
 
                                 $jsonArray += Add-File `
-                                    -is64Bit $is64Bit `
+                                    -is64Bit $setting.is64Bit `
                                     -detectionType $setting.Rules_ConstantDataType `
                                     -detectionValue $setting.Rules_ConstantValue `
                                     -fileOrFolderName $setting.Filter `

--- a/Private/New-IntuneDetection.ps1
+++ b/Private/New-IntuneDetection.ps1
@@ -1,0 +1,189 @@
+<#
+.Synopsis
+Created on:   17/03/2024
+Update on:    17/03/2024
+Created by:   Ben Whitmore
+Filename:     New-IntuneDetection.ps1
+
+.Description
+Function to get the local detection methods from the detection methods xml object
+
+.PARAMETER LogId
+The component (script name) passed as LogID to the 'Write-Log' function. 
+This parameter is built from the line number of the call from the function up the
+
+.PARAMETER LocalSettings
+The local detection method settings array to convert to JSON
+
+.PARAMETER Script
+The local detection method script to prepare
+#>
+
+function New-IntuneDetectionMethod {
+    param (
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = "The component (script name) passed as LogID to the 'Write-Log' function")]
+        [string]$LogId = $($MyInvocation.MyCommand).Name,
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 0, HelpMessage = 'The local detection method settings array to convert to JSON', ParameterSetName = 'Methods')]
+        [object]$LocalSettings,
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 1, HelpMessage = 'The local detection method script to prepare', ParameterSetName = 'Methods')]
+        [object]$Script
+    )
+    begin {
+
+        # Helper functions to create the JSON objects
+        # Registry detection method
+        function Add-SimpleSetting {
+            param(
+                [bool]$check32BitOn64System,
+                [string]$keyPath,
+                [string]$valueName,
+                [string]$operator,
+                [string]$version,
+                [string]$detectionValue
+                
+            )
+            $object = [PSCustomObject]@{
+                '@odata.type'          = '#microsoft.graph.win32LobAppRegistryDetection'
+                'check32BitOn64System' = $check32BitOn64System
+                'detectionType'        = $detectionType
+                'detectionValue'       = $detectionValue
+                'keyPath'              = $keyPath
+                'operator'             = $operator
+                'valueName'            = $valueName
+            }
+            return $object
+        }
+        
+        # File or Folder detection method
+        function Add-File {
+            param(
+                [bool]$check32BitOn64System,
+                [string]$detectionType,
+                [string]$detectionValue,
+                [string]$fileOrFolderName,
+                [string]$operator,
+                [string]$path
+            )
+            $object = [PSCustomObject]@{
+                '@odata.type'          = '#microsoft.graph.win32LobAppFileSystemDetection'
+                'check32BitOn64System' = $check32BitOn64System
+                'detectionType'        = $detectionType
+                'detectionValue'       = $detectionValue
+                'fileOrFolderName'     = $fileOrFolderName
+                'operator'             = $operator
+                'path'                 = $path
+
+            }
+            return $object
+        }
+        
+        # MSI detection method
+        function Add-MSI {
+            param(
+                [string]$productCode,
+                [string]$productVersion,
+                [string]$productVersionOperator
+            )
+            $object = [PSCustomObject]@{
+                '@odata.type'            = '#microsoft.graph.win32LobAppProductCodeDetection'
+                'productCode'            = $productCode
+                'productVersion'         = $productVersion
+                'productVersionOperator' = $productVersionOperator
+            }
+            return $object
+        }
+    }
+    process {
+
+        if ($PSCmdlet.ParameterSetName -eq 'Methods') {
+
+            # Check if more than one parameter was passed within the parameter set
+        
+            if ($PSBoundParameters.Keys.Count -gt 1) {
+                Write-Log -Message 'Only one parameter is allowed in parameter set "Methods". Choose either "LocalSettings" or "Script"' -LogId $LogId -Severity 3
+                Write-Host 'Only one parameter is allowed in parameter set "Methods". Choose either "LocalSettings" or "Script"' -ForegroundColor Red
+                return
+            }
+            else {
+
+                # Check if the LocalSettings or script parameter was passed
+                if ($PSBoundParameters['LocalSettings']) {
+                    $settings = $Settings
+                }
+                elseif ($PSBoundParameters['Script']) {
+                }
+                else {
+                    Write-Log -Message 'No settings were passed to the function' -LogId $LogId -Severity 3
+                    Write-Host 'No settings were passed to the function' -ForegroundColor Red
+                    return
+                }
+
+                # Check if the LocalSettings parameter was passed
+
+                if ($PSBoundParameters['LocalSettings']) {
+
+                    # Create an empty array to store the JSON objects
+                    $jsonArray = @()
+
+                    foreach ($setting in $Localsettings) {
+
+                        Switch ($setting.Type) {
+                            'SimpleSetting' {
+
+                                # Create the key path
+                                $regPath = Join-Path -Path $setting.Hive -ChildPath $setting.Key -ErrorAction SilentlyContinue
+
+                                # Create 64bit test
+                                if ($setting.Is64Bit -eq $true) {
+                                    $check32BitOn64System = [bool]$true
+                                }
+                                else {
+                                    $check32BitOn64System = [bool]$false
+                                }
+
+                                # Check detection type
+                                if ($setting.Rules_ConstantDataType -eq 'String') {
+                                    $detectionType = 'string'
+                                }
+                                elseif ($setting.Rules_ConstantDataType -like '*version') {
+                                    $detectionType = 'version'
+                                } 
+
+                                $jsonArray += Add-SimpleSetting `
+                                    -check32BitOn64System $check32BitOn64System `
+                                    -keyPath $regPath `
+                                    -valueName $setting.ValueName `
+                                    -operator $setting.Rules_Operator `
+                                    -detectionType $detectionType `
+                                    -detectionValue $setting.Rules_ConstantValue `
+                            
+                            }
+                            'File' {
+                                $jsonArray += Add-File -path $setting.Directory -fileName $setting.Name -is64Bit $setting.Is64Bit
+                            }
+                            'MSI' {
+                                $jsonArray += Add-MSI -productCode $setting.ProductCode
+                            }
+                        }
+                    }
+                }
+
+                # $jsonArray += Add-SimpleSetting -keyPath "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Notepad++" -valueName "DisplayVersion" -operator "Equals" -detectionValue "8.4.9" -is64Bit $true
+                #$jsonArray += Add-File -path "C:\Windows" -fileName "Cheese.txt" -is64Bit $false
+                #$jsonArray += Add-File -path "C:\Windows" -fileName "Cheese2.txt" -is64Bit $false
+                #$jsonArray += Add-MSI -productCode "{00478901-CD97-4A20-8FF3-3276865A2B44}"
+            
+                # Convert the array to JSON
+                $json = $jsonArray | ConvertTo-Json -Depth 10
+            
+                # Display or output the JSON
+                $json
+            }
+        }
+        else {
+            Write-Log -Message 'At least one parameter from parameter set "Methods" is required. Choose either "LocalSettings" or "Script"' -LogId $LogId -Severity 3
+            Write-Host 'At least one parameter from parameter set "Methods" is required. Choose either "LocalSettings" or "Script"' -ForegroundColor Red
+            return
+        }
+    }
+}

--- a/Private/New-IntuneWin.ps1
+++ b/Private/New-IntuneWin.ps1
@@ -60,6 +60,9 @@ function New-IntuneWin {
         elseif ($SetupFile -match "\.bat") {
             $commandToUse = Get-InstallCommand -InstallTech '.bat' -SetupFile $SetupFile
         }
+        elseif ($SetupFile -match "\.js") {
+            $commandToUse = Get-InstallCommand -InstallTech '.js' -SetupFile $SetupFile
+        }
         else {
             # Handle the default case if none of the conditions match
             Write-Host "No matching extension found."

--- a/Private/New-Win32appFramework.ps1
+++ b/Private/New-Win32appFramework.ps1
@@ -1,0 +1,29 @@
+<#
+.Synopsis
+Created on:   24/03/2024
+Created by:   Ben Whitmore
+Filename:     New-Win32appFramework.ps1
+
+.Description
+Function to create a Win32 app JSON framework
+
+.PARAMETER LogId
+The component (script name) passed as LogID to the 'Write-Log' function. 
+This parameter is built from the line number of the call from the function up the pipeline
+
+#>
+function New-IntuneWinFramework {
+    param(
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, HelpMessage = 'The component (script name) passed as LogID to the Write-Log function')]
+        [string]$LogId = $($MyInvocation.MyCommand).Name,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $false, Position = 0, HelpMessage = 'Param1')]
+        [string]$Param1
+
+    )
+    begin {
+        Write-Log -Message "Function: New-Win32appFramework was called" -Log "Main.log"
+    }
+    process {
+
+    }
+}

--- a/Public/New-Win32App.ps1
+++ b/Public/New-Win32App.ps1
@@ -1,7 +1,7 @@
 ﻿<#
 .Synopsis
 Created on:   14/03/2021
-Updated on:   13/01/2024
+Updated on:   23/03/2024
 Created by:   Ben Whitmore
 Filename:     New-Win32App.ps1
 
@@ -155,7 +155,7 @@ function New-Win32App {
     #region Create_Folders
     Write-Host "Creating additionl folders..." -ForegroundColor Cyan
     Write-Log -Message ("New-FolderToCreate -Root '{0}' -FolderNames @('Icons', 'Content', 'ContentPrepTool', 'DetectionMethods','Details', 'Win32Apps')" -f $workingFolder_Root) -LogId $LogId
-    New-FolderToCreate -Root $workingFolder_Root -FolderNames @('Icons', 'Content', 'ContentPrepTool', 'DetectionMethods','Details', 'Win32Apps')
+    New-FolderToCreate -Root $workingFolder_Root -FolderNames @('Icons', 'Content', 'ContentPrepTool', 'DetectionMethods', 'Details', 'Win32Apps')
     #endRegion
 
     #region Get_Content_Tool
@@ -318,10 +318,18 @@ function New-Win32App {
         Write-Log -Message "The 'ExportIcon' parameter passed" -LogId $LogId
 
         foreach ($applicationIcon in $app_Array) {
-            Write-Log -Message ("Exporting icon for '{0}' to '{1}'" -f $applicationIcon.Name, $applicationIcon.IconPath) -Logid $LogId
-            Write-Host ("Exporting icon for '{0}' to '{1}'" -f $applicationIcon.Name, $applicationIcon.IconPath) -ForegroundColor Cyan
 
-            Export-Icon -AppName $applicationIcon.Name -IconPath $applicationIcon.IconPath -IconData $applicationIcon.IconData
+            if ([string]::IsNullOrWhiteSpace($applicationIcon.IconData)) {
+                Write-Log -Message ("No icon data found for '{0}'. Skipping icon export" -f $applicationIcon.Name) -LogId $LogId -Severity 2
+                Write-Host ("No icon data found for '{0}'. Skipping icon export" -f $applicationIcon.Name) -ForegroundColor Yellow
+            }
+            else {
+                Write-Log -Message ("Exporting icon for '{0}' to '{1}'" -f $applicationIcon.Name, $applicationIcon.IconPath) -Logid $LogId
+                Write-Host ("Exporting icon for '{0}' to '{1}'" -f $applicationIcon.Name, $applicationIcon.IconPath) -ForegroundColor Cyan
+                
+                # Export the icon to disk
+                Export-Icon -AppName $applicationIcon.Name -IconPath $applicationIcon.IconPath -IconData $applicationIcon.IconData
+            }
         }
     }
     else {

--- a/Public/New-Win32App.ps1
+++ b/Public/New-Win32App.ps1
@@ -1,7 +1,7 @@
 ﻿<#
 .Synopsis
 Created on:   14/03/2021
-Updated on:   12/11/2023
+Updated on:   16/12/2023
 Created by:   Ben Whitmore
 Filename:     New-Win32App.ps1
 
@@ -349,10 +349,21 @@ function New-Win32App {
             
             # Build parameters to splat at the New-IntuneWin function
             $paramsToPassIntuneWin = @{}
-            $paramsToPassIntuneWin.Add('ContentFolder', $content.Install_Destination)
+
+            # If DownloadContent switch is not passed we will use content from the Configmgr source folder
+            if ($DownloadContent) {
+                $paramsToPassIntuneWin.Add('ContentFolder', $content.Install_Destination)
+            }
+            else {
+                $paramsToPassIntuneWin.Add('ContentFolder', $content.Install_Source)
+            }
+            
             $paramsToPassIntuneWin.Add('OutputFolder', (Join-Path -Path "$workingFolder_Root\Win32Apps" -ChildPath $content.Win32app_Destination))
             $paramsToPassIntuneWin.Add('SetupFile', $content.Install_CommandLine)
-            if ($OverrideIntuneWin32FileName) { $paramsToPassIntuneWin.Add('OverrideIntuneWin32FileName', $OverrideIntuneWin32FileName) }
+
+            if ($OverrideIntuneWin32FileName) { 
+                $paramsToPassIntuneWin.Add('OverrideIntuneWin32FileName', $OverrideIntuneWin32FileName) 
+            }
 
             # Create the .intunewin file
             New-IntuneWin @paramsToPassIntuneWin

--- a/Public/New-Win32App.ps1
+++ b/Public/New-Win32App.ps1
@@ -1,7 +1,7 @@
 ﻿<#
 .Synopsis
 Created on:   14/03/2021
-Updated on:   16/12/2023
+Updated on:   13/01/2024
 Created by:   Ben Whitmore
 Filename:     New-Win32App.ps1
 
@@ -154,8 +154,8 @@ function New-Win32App {
 
     #region Create_Folders
     Write-Host "Creating additionl folders..." -ForegroundColor Cyan
-    Write-Log -Message ("New-FolderToCreate -Root '{0}' -FolderNames @('Icons', 'Content', 'ContentPrepTool', 'Details', 'Win32Apps')" -f $workingFolder_Root) -LogId $LogId
-    New-FolderToCreate -Root $workingFolder_Root -FolderNames @('Icons', 'Content', 'ContentPrepTool', 'Details', 'Win32Apps')
+    Write-Log -Message ("New-FolderToCreate -Root '{0}' -FolderNames @('Icons', 'Content', 'ContentPrepTool', 'DetectionMethods','Details', 'Win32Apps')" -f $workingFolder_Root) -LogId $LogId
+    New-FolderToCreate -Root $workingFolder_Root -FolderNames @('Icons', 'Content', 'ContentPrepTool', 'DetectionMethods','Details', 'Win32Apps')
     #endRegion
 
     #region Get_Content_Tool

--- a/Public/New-Win32App.ps1
+++ b/Public/New-Win32App.ps1
@@ -305,7 +305,9 @@ function New-Win32App {
     Export-CsvDetails -Name 'DeploymentTypes' -Data $deploymentTypes_Array -Path $detailsFolder
 
     # Export content information to CSV for reference
-    Export-CsvDetails -Name 'Content' -Data $content_Array -Path $detailsFolder
+    if ($DownloadContent) {
+        Export-CsvDetails -Name 'Content' -Data $content_Array -Path $detailsFolder
+    }
     #endregion
 
     #region Exporting_Logos
@@ -357,7 +359,7 @@ function New-Win32App {
             else {
                 $paramsToPassIntuneWin.Add('ContentFolder', $content.Install_Source)
             }
-            
+
             $paramsToPassIntuneWin.Add('OutputFolder', (Join-Path -Path "$workingFolder_Root\Win32Apps" -ChildPath $content.Win32app_Destination))
             $paramsToPassIntuneWin.Add('SetupFile', $content.Install_CommandLine)
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -14,6 +14,7 @@
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18  
 ✅ Updated Licence terms to GNU GENERAL PUBLIC LICENSE  
 ✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script  
+✅ New module New-IntuneDetectionMethod to create json for detection methods
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -13,6 +13,8 @@
 ✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18
+✅ Updated Licence terms to MIT
+✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,6 +1,6 @@
 # Win32App Migration Tool - Release Notes
 
-## 2.0.20 - BETA - 16/03/2024
+## 2.0.20 - BETA - 23/03/2024
 
 ✅ Export Detection Method to file in the working folder 'DetectionMethods' folder  
 ✅ Export Detection Method supporting information to Details\DeploymentTypes.csv  
@@ -15,6 +15,7 @@
 ✅ Updated Licence terms to GNU GENERAL PUBLIC LICENSE  
 ✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script  
 ✅ New module New-IntuneDetectionMethod to create json for detection methods
+✅ Fixed an issue where icon export was attempted even if the icon was not present
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -12,7 +12,7 @@
 ✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected  
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17  
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18  
-✅ Updated Licence terms to GNU GENERAL PUBLIC LICENSE
+✅ Updated Licence terms to GNU GENERAL PUBLIC LICENSE  
 ✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script  
 
 ## 2.0.19 - BETA - 16/12/2023

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,8 +1,9 @@
 # Win32App Migration Tool - Release Notes
 
 ## 2.0.19 - BETA - 16/12/2023
-  
+
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/11
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/12
 
 ## 2.0.18 - BETA - 25/11/2023
   

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -12,7 +12,7 @@
 ✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected  
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17  
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18  
-✅ Updated Licence terms to MIT  
+✅ Updated Licence terms to GNU GENERAL PUBLIC LICENSE
 ✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script  
 
 ## 2.0.19 - BETA - 16/12/2023

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -10,6 +10,7 @@
 ✅ New module Connect-Graph (in development)
 ✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script (in development)
 ✅ Fixed an issue outputting Detection Method Scripts to file. We now use the .NET method which is much more reliable than Out-File
+✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,5 +1,9 @@
 # Win32App Migration Tool - Release Notes
 
+## 2.0.19 - BETA - 03/12/2023
+  
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/
+
 ## 2.0.18 - BETA - 25/11/2023
   
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/7  

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,6 +1,6 @@
 # Win32App Migration Tool - Release Notes
 
-## 2.0.20 - BETA - 17/02/2024
+## 2.0.20 - BETA - 03/03/2024
 
 ✅ Export Detection Method to file in the working folder 'DetectionMethods' folder
 ✅ Export Detection Method supporting information to Details\DeploymentTypes.csv
@@ -11,6 +11,8 @@
 ✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script (in development)
 ✅ Fixed an issue outputting Detection Method Scripts to file. We now use the .NET method which is much more reliable than Out-File
 ✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -2,24 +2,24 @@
 
 ## 2.0.20 - BETA - 03/03/2024
 
-✅ Export Detection Method to file in the working folder 'DetectionMethods' folder
-✅ Export Detection Method supporting information to Details\DeploymentTypes.csv
-✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1
-✅ Fix a bug where base64 icon data causes cmtrace to not parse the log line correctly. We now omit icondata from being logged
-✅ Fix a bug where an incorrect parameter was passed when testing the SMS Provider connection
-✅ New module Connect-Graph (in development)
-✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script (in development)
-✅ Fixed an issue outputting Detection Method Scripts to file. We now use the .NET method which is much more reliable than Out-File
-✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected
-✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17
-✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18
-✅ Updated Licence terms to MIT
-✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script
+✅ Export Detection Method to file in the working folder 'DetectionMethods' folder  
+✅ Export Detection Method supporting information to Details\DeploymentTypes.csv  
+✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1  
+✅ Fix a bug where base64 icon data causes cmtrace to not parse the log line correctly. We now omit icondata from being logged  
+✅ Fix a bug where an incorrect parameter was passed when testing the SMS Provider connection  
+✅ New module Connect-Graph (in development)  
+✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script (in development)  
+✅ Fixed an issue outputting Detection Method Scripts to file. We now use the .NET method which is much more reliable than Out-File  
+✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected  
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17  
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18  
+✅ Updated Licence terms to MIT  
+✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script  
 
 ## 2.0.19 - BETA - 16/12/2023
 
-✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/11
-✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/12
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/11  
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/12  
 
 ## 2.0.18 - BETA - 25/11/2023
   

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,5 +1,11 @@
 # Win32App Migration Tool - Release Notes
 
+## 2.0.20 - BETA - 13/01/2024
+
+✅ Export Detection Method to file in the working folder 'DetectionMethods' folder
+✅ Export Detection Method supporting information to Details\DeploymentTypes.csv
+✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1
+
 ## 2.0.19 - BETA - 16/12/2023
 
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/11

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,8 +1,8 @@
 # Win32App Migration Tool - Release Notes
 
-## 2.0.19 - BETA - 03/12/2023
+## 2.0.19 - BETA - 16/12/2023
   
-✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/
+✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/11
 
 ## 2.0.18 - BETA - 25/11/2023
   

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,10 +1,11 @@
 # Win32App Migration Tool - Release Notes
 
-## 2.0.20 - BETA - 13/01/2024
+## 2.0.20 - BETA - 20/01/2024
 
 ✅ Export Detection Method to file in the working folder 'DetectionMethods' folder
 ✅ Export Detection Method supporting information to Details\DeploymentTypes.csv
 ✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1
+✅ Fix a bug where base64 icon data causes cmtrace to not parse the log line correctly. We now omit icondata from being logged
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,12 +1,14 @@
 # Win32App Migration Tool - Release Notes
 
-## 2.0.20 - BETA - 20/01/2024
+## 2.0.20 - BETA - 17/02/2024
 
 ✅ Export Detection Method to file in the working folder 'DetectionMethods' folder
 ✅ Export Detection Method supporting information to Details\DeploymentTypes.csv
 ✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1
 ✅ Fix a bug where base64 icon data causes cmtrace to not parse the log line correctly. We now omit icondata from being logged
+✅ Fix a bug where an incorrect parameter was passed when testing the SMS Provider connection
 ✅ New module Connect-Graph (in development)
+✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script (in development)
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -9,6 +9,7 @@
 ✅ Fix a bug where an incorrect parameter was passed when testing the SMS Provider connection
 ✅ New module Connect-Graph (in development)
 ✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script (in development)
+✅ Fixed an issue outputting Detection Method Scripts to file. We now use the .NET method which is much more reliable than Out-File
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -6,6 +6,7 @@
 ✅ Export Detection Method supporting information to Details\DeploymentTypes.csv
 ✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1
 ✅ Fix a bug where base64 icon data causes cmtrace to not parse the log line correctly. We now omit icondata from being logged
+✅ New module Connect-Graph (in development)
 
 ## 2.0.19 - BETA - 16/12/2023
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,14 +1,13 @@
 # Win32App Migration Tool - Release Notes
 
-## 2.0.20 - BETA - 03/03/2024
+## 2.0.20 - BETA - 16/03/2024
 
 ✅ Export Detection Method to file in the working folder 'DetectionMethods' folder  
 ✅ Export Detection Method supporting information to Details\DeploymentTypes.csv  
 ✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1  
 ✅ Fix a bug where base64 icon data causes cmtrace to not parse the log line correctly. We now omit icondata from being logged  
 ✅ Fix a bug where an incorrect parameter was passed when testing the SMS Provider connection  
-✅ New module Connect-Graph (in development)  
-✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script (in development)  
+✅ New module Connect-Graph (in development)   
 ✅ Fixed an issue outputting Detection Method Scripts to file. We now use the .NET method which is much more reliable than Out-File  
 ✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected  
 ✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17  

--- a/Win32AppMigrationTool.psd1
+++ b/Win32AppMigrationTool.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Win32AppMigrationTool.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.0.18'
+    ModuleVersion     = '2.0.19'
    
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Win32AppMigrationTool.psd1
+++ b/Win32AppMigrationTool.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Win32AppMigrationTool.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.0.19'
+    ModuleVersion     = '2.0.20'
    
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Win32AppMigrationTool.psm1
+++ b/Win32AppMigrationTool.psm1
@@ -1,21 +1,22 @@
 <#
 .Synopsis
-Created on:   12/11/2023
+Created on:   16/12/2023
 Created by:   Ben Whitmore
 Filename:     Win32AppMigrationTool.psm1
 
 .Description
 Win32App Packaging Tool Function Import
 #>
+
 $PublicFunctions = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse -ErrorAction SilentlyContinue )
 $PrivateFunctions = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -Recurse -ErrorAction SilentlyContinue )
 
 foreach ($GetFunction in @($PublicFunctions + $PrivateFunctions)) {
-    Try {
+    try {
         . $GetFunction.FullName
     }
-    Catch {
-        Write-Host "Failed to import function $($GetFunction.FullName)" -ForegroundColor Red
-        Write-Host "$_" -ForegroundColor Yellow
+    catch {
+        Write-Error -Message ("Failed to import function '{0}'" -f $GetFunction.FullName)
+        throw
     }
 }


### PR DESCRIPTION
## 2.0.20 - BETA - 23/03/2024

✅ Export Detection Method to file in the working folder 'DetectionMethods' folder  
✅ Export Detection Method supporting information to Details\DeploymentTypes.csv  
✅ Fix an incorrectly passed parameter for Get-ScriptEnd in Get-DeploymentTypeInfo.ps1  
✅ Fix a bug where base64 icon data causes cmtrace to not parse the log line correctly. We now omit icondata from being logged  
✅ Fix a bug where an incorrect parameter was passed when testing the SMS Provider connection  
✅ New module Connect-Graph (in development)   
✅ Fixed an issue outputting Detection Method Scripts to file. We now use the .NET method which is much more reliable than Out-File  
✅ Fixed a bug where return $applicationTypes was not outside the ForEach loop and only returned a single application even if multiple were selected  
✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/17  
✅ Fixed https://github.com/byteben/Win32App-Migration-Tool/issues/18  
✅ Updated Licence terms to GNU GENERAL PUBLIC LICENSE  
✅ New module Get-LocalDetectionMethods to extract local detection methods (file/reg/msi) when detection is not a script  
✅ New module New-IntuneDetectionMethod to create json for detection methods
✅ Fixed an issue where icon export was attempted even if the icon was not present