### PR TITLE
Version 3.0.03

### DIFF
--- a/Private/Get-DeploymentTypeInfo.ps1
+++ b/Private/Get-DeploymentTypeInfo.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   28/10/2023
-Updated on:    01/01/2025
+Updated on:   03/01/2025
 Created by:   Ben Whitmore
 Filename:     Get-DeploymentTypeInfo.ps1
 
@@ -110,6 +110,8 @@ function Get-DeploymentTypeInfo {
 
                         # If Detection Method is a 'Script'
                         'Script' {
+
+                            Write-LogAndHost -Message 'Detection Method Provider is Script' -LogId $LogId -ForegroundColor Green
                             $detectionTypeScriptBody = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ScriptBody' }).InnerText
                             $detectionTypeScriptRunAs32Bit = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'RunAs32Bit' }).InnerText
                             $detectionTypeExecutionContext = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ExecutionContext' }).InnerText
@@ -176,6 +178,7 @@ function Get-DeploymentTypeInfo {
 
                         # If Detection Method is File/Reg/MSICode
                         'Local' {
+                            Write-LogAndHost -Message 'Detection Method Provider is Local' -LogId $LogId -ForegroundColor Green
                             $detectionTypeExecutionContext = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ExecutionContext' }).InnerText
                             $detectionTypeMethodBody = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'MethodBody' }).InnerText
                             
@@ -231,6 +234,15 @@ function Get-DeploymentTypeInfo {
                                 Write-LogAndHost -Message ("There was an error getting the local detection methods for deployment type '{0}' from the XML" -f $detectionMethodXmlFile) -LogId $LogId -Severity 3
                             }
                         }
+                        'MSI' {
+
+                            Write-LogAndHost -Message 'Detection Method Provider is MSI' -LogId $LogId -ForegroundColor Green
+                            $detectionTypeExecutionContext = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ExecutionContext' }).InnerText
+                            $detectionTypeProductCode = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'ProductCode' }).InnerText
+                            $detectionTypePackageCode = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'PackageCode' }).InnerText
+                            $detectionTypePatchCodes = $object.Installer.DetectAction.Args.Arg.Where({ $_.Name -eq 'PatchCodes' }).InnerText
+
+                        }
                     }
                     
                     # Add detection method details to the PSCustomObject
@@ -240,11 +252,15 @@ function Get-DeploymentTypeInfo {
                     $deploymentObject | Add-Member NoteProperty -Name DetectionMethodScriptFile -Value $detectionMethodFile
                     $deploymentObject | Add-Member NoteProperty -Name DetectionMethodXmlFile -Value $detectionMethodXmlFile
                     $deploymentObject | Add-Member NoteProperty -Name DetectionMethodJsonFile -Value $detectionMethodJsonFile
+                    $deploymentObject | Add-Member NoteProperty -Name DetectionTypeProductCode -Value $detectionTypeProductCode
+                    $deploymentObject | Add-Member NoteProperty -Name DetectionTypePackageCode -Value $detectionTypePackageCode
+                    $deploymentObject | Add-Member NoteProperty -Name DetectionTypePatchCodes -Value $detectionTypePatchCodes
 
                     Write-Log -Message ("Application_Id = '{0}', Application_Name = '{1}', Application_LogicalName = '{2}', LogicalName = '{3}', Name = '{4}', `
                     Technology = '{5}', ExecutionContext = '{6}', InstallContext = '{7}', InstallCommandLine = '{8}', UninstallSetting = '{9}', UninstallContent = '{10}', `
                     UninstallCommandLine = '{11}', ExecuteTime = '{12}', MaxExecuteTime = '{13}', DetectionProvider = '{14}', DetectionTypeScriptRunAs32Bit = '{15}', `
-                    DetectionTypeScriptType = '{16}', DetectionTypeExecutionContext = '{17}', DetectionMethodScriptFile = '{18}', DetectionMethodXmlFile = '{19}', DetectionMethodJsonFile = '{20}'" -f `
+                    DetectionTypeScriptType = '{16}', DetectionTypeExecutionContext = '{17}', DetectionMethodScriptFile = '{18}', DetectionMethodXmlFile = '{19}', `
+                    DetectionMethodJsonFile = '{20}', DetectionTypeProductCode = '{21}', DetectionTypePackageCode = '{22}', DetectionTypePatchCodes = '{23}'" -f `
                             $ApplicationId, `
                             $xmlContent.AppMgmtDigest.Application.title.'#text', `
                             $xmlContent.AppMgmtDigest.Application.LogicalName, `
@@ -265,7 +281,10 @@ function Get-DeploymentTypeInfo {
                             $detectionTypeExecutionContext, `
                             $detectionMethodScriptFile, `
                             $detectionMethodXmlFile, `
-                            $detectionMethodJsonFile) -LogId $LogId
+                            $detectionMethodJsonFile, `
+                            $detectionTypeProductCode, `
+                            $detectionMethodPackageCode, `
+                            $detectionMethodPatchCodes) -LogId $LogId
 
                     # Output the deployment type object
                     Write-Host "`nDeplopymentType Details extracted" -ForegroundColor Cyan

--- a/Private/Get-InstallCommand.ps1
+++ b/Private/Get-InstallCommand.ps1
@@ -36,7 +36,7 @@ function Get-InstallCommand {
         Write-LogAndHost -Message ("'{0}' installer type was detected" -f $InstallTech) -LogId $LogId -ForegroundColor Green
 
         # Build the command to be used with the Win32 Content Prep Tool
-        $right = ($SetupFile -split "$InstallTech")[0]
+        $right = ($SetupFile -split [regex]::Escape("$InstallTech"))[0]
         $rightMod = ($right -split '["'']')[-1]
         $fileName = $rightMod.TrimStart("\", ".", "`"", "'", " ")
         $command = $fileName + $InstallTech

--- a/Private/Get-LocalDetectionMethods.ps1
+++ b/Private/Get-LocalDetectionMethods.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   17/02/2024
-Update on:    01/01/2025
+Update on:    04/01/2025
 Created by:   Ben Whitmore
 Filename:     Get-LocalDetectionMethods.ps1
 
@@ -51,6 +51,7 @@ function Get-DetectionMethod {
                     if (-not $rules.Value.ContainsKey($logicalName)) {
                         $rules.Value[$logicalName] = @()
                     }
+
                     $parentExpression = $node.ParentNode.ParentNode
                     $ruleDetail = @{
                         Operator         = $parentExpression.Operator
@@ -73,8 +74,17 @@ function Get-DetectionMethod {
         $rules = @{}
 
         # Find SettingReferences in the first level of the EnhancedDetectionMethod
-        $xmlDocument.EnhancedDetectionMethod.Rule.Expression.Operands.Expression | ForEach-Object {
-            Find-SettingReferences -Node $_ -Rules ([ref]$rules)
+        if ($xmlDocument.EnhancedDetectionMethod.Rule.Expression.Operands.Expression) {
+            $xmlDocument.EnhancedDetectionMethod.Rule.Expression.Operands.Expression | ForEach-Object {
+                Find-SettingReferences -Node $_ -Rules ([ref]$rules)
+            }
+        }
+
+        # Find SettingReferences if a child operands node doesn't exist
+        elseif ($xmlDocument.EnhancedDetectionMethod.Rule.Expression) {
+            $xmlDocument.EnhancedDetectionMethod.Rule.Expression | ForEach-Object {
+                Find-SettingReferences -Node $_ -Rules ([ref]$rules)
+            }
         }
         
         # Create an array to store the settings

--- a/Private/New-FolderToCreate.ps1
+++ b/Private/New-FolderToCreate.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   27/10/2023
-Updated on:   01/01/2025
+Updated on:   03/01/2025
 Created by:   Ben Whitmore
 Filename:     New-FolderToCreate.ps1
 
@@ -52,7 +52,7 @@ function New-FolderToCreate {
                 }
             }
             else {
-                Write-Host -Message ("Folder '{0}' already exists. Skipping folder creation" -f $folderToCreate)
+                Write-Host -Message ("Folder '{0}' already exists. Skipping folder creation" -f $folderToCreate) -ForegroundColor Yellow
             }
         }
     }

--- a/Private/New-FolderToCreate.ps1
+++ b/Private/New-FolderToCreate.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   27/10/2023
-Updated on:   03/01/2025
+Updated on:   04/01/2025
 Created by:   Ben Whitmore
 Filename:     New-FolderToCreate.ps1
 
@@ -29,7 +29,7 @@ function New-FolderToCreate {
     )
     begin {
     
-        Write-Host -Message 'Function: New-FolderToCreate was called' -ForegroundColor Cyan
+        Write-Host 'Function: New-FolderToCreate was called' -ForegroundColor Cyan
     }
     process {
         foreach ($folder in $FolderNames) {
@@ -38,21 +38,21 @@ function New-FolderToCreate {
             $folderToCreate = Join-Path -Path $Root -ChildPath $folder
         
             if (-not (Test-Path -Path $folderToCreate)) {
-                Write-Host -Message ("Creating Folder '{0}'..." -f $folderToCreate) -ForegroundColor Cyan
+                Write-Host ("Creating Folder '{0}'..." -f $folderToCreate) -ForegroundColor Cyan
 
                 try {
 
                     # Create the folder
                     New-Item -Path $folderToCreate -ItemType Directory -Force -ErrorAction Stop | Out-Null
-                    Write-Host -Message ("Folder '{0}' was created succesfully" -f $folderToCreate) -ForegroundColor Green
+                    Write-Host ("Folder '{0}' was created succesfully" -f $folderToCreate) -ForegroundColor Green
                 }
                 catch {
-                    Write-Host -Message ("Couldn't create '{0}' folder" -f $folderToCreate) -Severity 3
+                    Write-Host ("Couldn't create '{0}' folder" -f $folderToCreate) -Severity 3
                     Get-ScriptEnd -LogId $LogId -Message $_.Exception.Message
                 }
             }
             else {
-                Write-Host -Message ("Folder '{0}' already exists. Skipping folder creation" -f $folderToCreate) -ForegroundColor Yellow
+                Write-Host ("Folder '{0}' already exists. Skipping folder creation" -f $folderToCreate) -ForegroundColor Yellow
             }
         }
     }

--- a/Private/New-IntuneFramework.ps1
+++ b/Private/New-IntuneFramework.ps1
@@ -55,6 +55,9 @@ The install command line for the app
 .PARAMETER UninstallCommandLine
 The uninstall command line for the app
 
+.PARAMETER UninstallCommandLineFallback
+The uninstall command line for the app if one is not provided. We set this to the InstallCommandLine by default. You could use "cmd /c" (which does nothing)
+
 .PARAMETER DetectionMethodJson
 The JSON body for the detection method of the app
 
@@ -119,27 +122,29 @@ function New-IntuneWinFramework {
         [string]$InstallCommandLine,
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 12, HelpMessage = "The uninstall command line for the app")]
         [string]$UninstallCommandLine,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 13, HelpMessage = "The JSON body for the detection method of the app")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 13, HelpMessage = "The uninstall command line for the app")]
+        [string]$UninstallCommandLineFallback = $InstallCommandLine,
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 14, HelpMessage = "The JSON body for the detection method of the app")]
         [string]$DetectionMethodJson,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 14, HelpMessage = "The base64 value of the detection method script for the app")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 15, HelpMessage = "The base64 value of the detection method script for the app")]
         [string]$DetectionScript,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 15, HelpMessage = "The MSI product information for detection")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 16, HelpMessage = "The MSI product information for detection")]
         [object]$DetectionMethodMSI,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 16, HelpMessage = "The minimum operating system architecture required for the app")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 17, HelpMessage = "The minimum operating system architecture required for the app")]
         [string]$MinimumOSArchitecture = 'x64,x86',
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 17, HelpMessage = "The minimum operating system version required for the app")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 18, HelpMessage = "The minimum operating system version required for the app")]
         [string]$MinimumOSVersion = "Windows10_21H2",
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 18, HelpMessage = "System or User")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 19, HelpMessage = "System or User")]
         [ValidateSet('System', 'User')]
         [string]$InstallExperience,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 19, HelpMessage = "The mdefault restart behavior for the app")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 20, HelpMessage = "The mdefault restart behavior for the app")]
         [ValidateSet("allow", "basedOnReturnCode", "suppress", "force")]
         [string]$RestartBehavior = "basedOnReturnCode",
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 20, HelpMessage = "The maximum time (in minutes) that the app is expected to take to execute")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 21, HelpMessage = "The maximum time (in minutes) that the app is expected to take to execute")]
         [int]$MaxExecutionTime = 60,
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, Position = 21, HelpMessage = "When creating the Win32App, allow the user to uninstall the app if it is available in the Company Portal")]
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, Position = 22, HelpMessage = "When creating the Win32App, allow the user to uninstall the app if it is available in the Company Portal")]
         [bool]$AllowAvailableUninstall,
-        [Parameter(Mandatory = $false, ValuefromPipeline = $false, Position = 22, HelpMessage = "Json string of default return codes")]
+        [Parameter(Mandatory = $false, ValuefromPipeline = $false, Position = 23, HelpMessage = "Json string of default return codes")]
         [string]$ReturnCodes = '{"0": "success","1707": "success","3010": "softReboot","1641": "hardReboot","1618": "retry"}'
     )
 
@@ -184,7 +189,7 @@ function New-IntuneWinFramework {
             fileName                       = $FileName
             setupFilePath                  = $SetupFile
             installCommandLine             = $deploymentType.InstallCommandLine
-            uninstallCommandLine           = $deploymentType.UninstallCommandLine
+            uninstallCommandLine           = if ([string]::IsNullOrEmpty($deploymentType.UninstallCommandLine)) { $UninstallCommandLineFallback } else { $deploymentType.UninstallCommandLine }
             minimumSupportedWindowsRelease = $MinimumOSVersion
             applicableArchitectures        = $MinimumOSArchitecture
         }

--- a/Private/New-IntuneWin.ps1
+++ b/Private/New-IntuneWin.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   11/11/2023
-Updated on:   01/01/2025
+Updated on:   04/01/2025
 Created by:   Ben Whitmore
 Filename:     New-IntuneWin.ps1
 
@@ -44,29 +44,41 @@ function New-IntuneWin {
 
         # Search the Install Command line for other the installer type
         if ($SetupFile -match "powershell" -and $SetupFile -match "\.ps1") {
+            Write-LogAndHost -Message "PowerShell script detected" -LogId $LogId -ForegroundColor Cyan
             $commandToUse = Get-InstallCommand -InstallTech '.ps1' -SetupFile $SetupFile
         }
         elseif ($SetupFile -match "\.exe" -and $SetupFile -notmatch "msiexec" -and $SetupFile -notmatch "cscript" -and $SetupFile -notmatch "wscript") {
+            Write-LogAndHost -Message "Executable detected" -LogId $LogId -ForegroundColor Cyan
             $commandToUse = Get-InstallCommand -InstallTech '.exe' -SetupFile $SetupFile
         }
         elseif ($SetupFile -match "\.msi") {
+            Write-LogAndHost -Message "MSI detected" -LogId $LogId -ForegroundColor Cyan
             $commandToUse = Get-InstallCommand -InstallTech '.msi' -SetupFile $SetupFile
         }
         elseif ($SetupFile -match "\.vbs") {
+            Write-LogAndHost -Message "VBScript detected" -LogId $LogId -ForegroundColor Cyan
             $commandToUse = Get-InstallCommand -InstallTech '.vbs' -SetupFile $SetupFile
         }
         elseif ($SetupFile -match "\.cmd") {
+            Write-LogAndHost -Message "CMD script detected" -LogId $LogId -ForegroundColor Cyan
             $commandToUse = Get-InstallCommand -InstallTech '.cmd' -SetupFile $SetupFile
         }
         elseif ($SetupFile -match "\.bat") {
+            Write-LogAndHost -Message "Batch script detected" -LogId $LogId -ForegroundColor Cyan
             $commandToUse = Get-InstallCommand -InstallTech '.bat' -SetupFile $SetupFile
         }
         elseif ($SetupFile -match "\.js") {
+            Write-LogAndHost -Message "JavaScript detected" -LogId $LogId -ForegroundColor Cyan
             $commandToUse = Get-InstallCommand -InstallTech '.js' -SetupFile $SetupFile
+        }
+        elseif ($SetupFile -match "\.exe" -and $SetupFile -match "msiexec") {
+            Write-LogAndHost -Message "Executable detected but command line contains msiexec (hmmmm - not sure what to do here. Will use .exe)" -LogId $LogId -ForegroundColor Cyan
+            $commandToUse = Get-InstallCommand -InstallTech '.exe' -SetupFile $SetupFile
         }
         else {
             # Handle the default case if none of the conditions match
-            Write-Host "No matching extension found."
+            Write-LogAndHost "No matching extension found." -LogId $LogId -Severity 3
+            Get-ScriptEnd -LogId $LogId
         }
     
         Write-LogAndHost -Message ("Building IntuneWinAppUtil.exe execution string: '{0}' -s '{1}' -c '{2}' -o '{3}'" -f "$workingFolder_Root\ContentPrepTool\IntuneWinAppUtil.exe", $commandToUse, $ContentFolder, $OutputFolder) -LogId $LogId -ForegroundColor Cyan

--- a/Private/New-VerboseRegion.ps1
+++ b/Private/New-VerboseRegion.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
 Created on:   26/10/2023
-Updated on:   01/01/2025
+Updated on:   03/01/2025
 Created by:   Ben Whitmore
 Filename:     New-VerboseRegion.ps1
 

--- a/Public/New-Win32App.ps1
+++ b/Public/New-Win32App.ps1
@@ -1,7 +1,7 @@
 ﻿<#
 .Synopsis
 Created on:   14/03/2021
-Updated on:   01/01/2025
+Updated on:   03/01/2025
 Created by:   Ben Whitmore
 Filename:     New-Win32App.ps1
 
@@ -592,7 +592,8 @@ function New-Win32App {
                         $paramsToPassWin32App = @{}
                         $paramsToPassWin32App.Add('Name', $app.Name)
                         $paramsToPassWin32App.Add('Description', $Description)
-                        $paramsToPassWin32App.Add('Publisher', $app.Publisher)
+                        $publisher = if ([string]::IsNullOrWhiteSpace($app.Publisher)) { "Not Specified" } else { $app.Publisher }
+                        $paramsToPassWin32App.Add('Publisher', $publisher)
                         $paramsToPassWin32App.Add('AppVersion', $app.Version)
                         $paramsToPassWin32App.Add('InformationURL', $app.InfoURL)
                         $paramsToPassWin32App.Add('PrivacyURL', $app.PrivacyURL)
@@ -625,6 +626,14 @@ function New-Win32App {
                         elseif ($deploymentType.DetectionTypeScriptType) {
                             $bytes = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Content -Path "$($deploymentType.DetectionMethodScriptFile)" -Raw -Encoding UTF8)))
                             $paramsToPassWin32App.Add('DetectionScript', $bytes)
+                        }
+                        elseif ($deploymentType.DetectionTypeProductCode) {
+                            $detectionMethodMSIArray = [ordered]@{
+                                ProductCode = $deploymentType.DetectionTypeProductCode
+                                PackageCode = $deploymentType.DetectionTypePackageCode
+                                PatchCodes  = $deploymentType.DetectionTypePatchCodes
+                            }
+                            $paramsToPassWin32App.Add('DetectionMethodMSI', $detectionMethodMSIArray)
                         }
                         else {
                             Write-LogAndHost -Message ("No detection method found for '{0}'" -f $app.Name) -LogId $LogId -Severity 3

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ You assume all risks and responsibilities associated with its usage.
   
 ## Development Status
 
-  **STATUS: Generally Available**  
-  The Win32App Migration Tool is now Generally Available as of January 2025. I would welcome feedback or suggestions for improvement. Reach out on Twitter to DM @byteben (DM's are open)  
+  **STATUS: Generally Available (Preview)**  
+  The Win32App Migration Tool is now Generally Available (in Preview) as of January 2025. I would welcome feedback or suggestions for improvement. Reach out on Twitter to DM @byteben (DM's are open)  
   
 ## Requirements  
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Instead of manually checking Application and Deployment Type information and gat
 
 This solution is distributed under the **GNU GENERAL PUBLIC LICENSE**.
 
-The PowerShell script provided is shared with the community *as-is*. The author and co-author(s) make no warranties or guarantees regarding its functionality, reliability, or suitability for any specific purpose. 
-Please note that the script may need to be modified or adapted to fit your specific environment or requirements. It is recommended to thoroughly test the script in a non-production environment before using it in a live or critical system. 
-The author and co-author(s) cannot be held responsible for any damages, losses, or adverse effects that may arise from the use of this script. 
+The PowerShell script provided is shared with the community *as-is*. The author and co-author(s) make no warranties or guarantees regarding its functionality, reliability, or suitability for any specific purpose.  
+Please note that the script may need to be modified or adapted to fit your specific environment or requirements. It is recommended to thoroughly test the script in a non-production environment before using it in a live or critical system.  
+The author and co-author(s) cannot be held responsible for any damages, losses, or adverse effects that may arise from the use of this script.  
 You assume all risks and responsibilities associated with its usage.
 
 ---

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,5 +1,11 @@
 # Win32App Migration Tool - Release Notes
 
+## 3.0.02 - General Availability - 03/01/2025  
+
+✅ Fixed styling issue in New-FolderToCreate function  
+✅ Added support for MSI detection methods  
+✅ Fixed <https://github.com/byteben/Win32App-Migration-Tool/issues/23>
+
 ## 3.0.01 - General Availability - 01/01/2025
 
 ✅ New Branch for 3.0.01

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,12 +1,25 @@
 # Win32App Migration Tool - Release Notes
 
-## 3.0.02 - General Availability - 03/01/2025  
+## 3.0.03 - General Availability (Preview) - 03/01/2025  
+
+✅ Fixed unexpecetd -Message output from the New-FolderToCreate function  
+✅ Removed unnecessary PSBoundParameters tests from the New-IntuneDetection function  
+✅ Fixed an issue with Find-SettingReferences if a child operands node doesn't exist in Get-LocalDetectionMethods function. We now test if the node exists before attempting to access it.
+✅ Fixed an issue with New-IntuneDetection function where we didnt pass the correct datatype and value for a local setting detection method in some cases  
+✅ Fixed an issue with New-IntuneDetection function where we were not converting Int64 datatype to integer for the Win32 app JSON detection method  
+✅ Fixed an issue with New-IntuneDetection function where we were not converting the operator 'Equals' to 'equal' for the Win32 app JSON detection method  
+✅ Improved error handling in New-IntuneWin if we cant find the extension of the install command  
+✅ We now select installer technoilogy .exe if the command line finds a -match "\.exe" -and -match "msiexec". This is to handle the case where the install command is an EXE but the command line contains msiexec (strange - I agree)  
+✅ Fixed an issue with how we get the name for the .intunewin filename from the install command line. We now escape the extension type for splitting [regex]::Escape("$InstallTech")  
+✅ Fixed an issue where no value was passsed if the ConfigMgr deplopyment type did not have an uninstall command. This is mandatory for the Win32 app JSON  
+
+## 3.0.02 - General Availability (Preview) - 03/01/2025  
 
 ✅ Fixed styling issue in New-FolderToCreate function  
 ✅ Added support for MSI detection methods  
 ✅ Fixed <https://github.com/byteben/Win32App-Migration-Tool/issues/23>
 
-## 3.0.01 - General Availability - 01/01/2025
+## 3.0.01 - General Availability (Preview) - 01/01/2025
 
 ✅ New Branch for 3.0.01
 ✅ Removed dependency on MSAL.PS and replaced with Microsoft.Graph.Authentication  

--- a/Win32AppMigrationTool.psd1
+++ b/Win32AppMigrationTool.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Win32AppMigrationTool.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '3.0.01'
+    ModuleVersion     = '3.0.02'
    
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Win32AppMigrationTool.psd1
+++ b/Win32AppMigrationTool.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Win32AppMigrationTool.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '3.0.02'
+    ModuleVersion     = '3.0.03'
    
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
## 3.0.03 - General Availability (Preview) - 03/01/2025  "BUG FIXES"

✅ Fixed unexpecetd -Message output from the New-FolderToCreate function  
✅ Removed unnecessary PSBoundParameters tests from the New-IntuneDetection function  
✅ Fixed an issue with Find-SettingReferences if a child operands node doesn't exist in Get-LocalDetectionMethods function. We now test if the node exists before attempting to access it.
✅ Fixed an issue with New-IntuneDetection function where we didnt pass the correct datatype and value for a local setting detection method in some cases  
✅ Fixed an issue with New-IntuneDetection function where we were not converting Int64 datatype to integer for the Win32 app JSON detection method  
✅ Fixed an issue with New-IntuneDetection function where we were not converting the operator 'Equals' to 'equal' for the Win32 app JSON detection method  
✅ Improved error handling in New-IntuneWin if we cant find the extension of the install command  
✅ We now select installer technoilogy .exe if the command line finds a -match "\.exe" -and -match "msiexec". This is to handle the case where the install command is an EXE but the command line contains msiexec (strange - I agree)  
✅ Fixed an issue with how we get the name for the .intunewin filename from the install command line. We now escape the extension type for splitting [regex]::Escape("$InstallTech")  
✅ Fixed an issue where no value was passsed if the ConfigMgr deplopyment type did not have an uninstall command. This is mandatory for the Win32 app JSON  