### PR TITLE
Added extra parameters, fixed wildcard handling and comment exclusion, and added handling for .msp files

### DIFF
--- a/Private/Get-AppList.ps1
+++ b/Private/Get-AppList.ps1
@@ -65,24 +65,24 @@ function Get-AppList {
                         $true {
                             switch ($NoOgv) {
                                 $true {
-                                    Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' excluding apps like '{1}' and where the comment field is like '{2}' (NoOgv parameter passed)" -f $AppName, $ExcludeFilter, $Pmpc_Comment) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Where-Object { (-not ($_.LocalizedDisplayName -like "$ExcludeFilter") ) -and (-not ($_.LocalizedDescription -like "$Pmpc_Comment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
+                                    Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' excluding apps like '{1}' and where the comment field is like '{2}' (NoOgv parameter passed)" -f $AppName, $ExcludeFilter, $PmpcComment) -LogId $LogId -ForegroundColor Cyan
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Where-Object { (-not ($_.LocalizedDisplayName -like "$ExcludeFilter") ) -and (-not ($_.LocalizedDescription -like "$PmpcComment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
                                 }
                                 $false {
                                     Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' excluding apps like '{1}'" -f $AppName, $ExcludeFilter) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Where-Object { (-not ($_.LocalizedDisplayName -like "$ExcludeFilter") ) -and (-not ($_.LocalizedDescription -like "$Pmpc_Comment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an application(s) to process the associated deployment types' -OutputMode Single
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Where-Object { (-not ($_.LocalizedDisplayName -like "$ExcludeFilter") ) -and (-not ($_.LocalizedDescription -like "$PmpcComment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an application(s) to process the associated deployment types' -OutputMode Single
                                 }
                             }
                         }
                         $false {
                             switch ($NoOgv) {
                                 $true {
-                                    Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' where the comment field is like '{1}' (NoOgv parameter passed)" -f $AppName, $Pmpc_Comment) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Where-Object { (-not ($_.LocalizedDescription -like "$Pmpc_Comment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
+                                    Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' where the comment field is like '{1}' (NoOgv parameter passed)" -f $AppName, $PmpcComment) -LogId $LogId -ForegroundColor Cyan
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Where-Object { (-not ($_.LocalizedDescription -like "$PmpcComment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
                                 }
                                 $false {
-                                    Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' where the comment field is like '{1}'" -f $AppName, $Pmpc_Comment) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Where-Object { (-not ($_.LocalizedDescription -like "$Pmpc_Comment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an application(s) to process the associated deployment types' -OutputMode Single
+                                    Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' where the comment field is like '{1}'" -f $AppName, $PmpcComment) -LogId $LogId -ForegroundColor Cyan
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Where-Object { (-not ($_.LocalizedDescription -like "$PmpcComment") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an application(s) to process the associated deployment types' -OutputMode Single
                                 }
                             }
                         }
@@ -94,11 +94,11 @@ function Get-AppList {
                             switch ($NoOgv) {
                                 $true {
                                     Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' excluding apps like '{1}' (NoOgv parameter passed)" -f $AppName, $ExcludeFilter) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Where-Object { (-not($_.LocalizedDisplayName -like "$ExcludeFilter")) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Where-Object { (-not($_.LocalizedDisplayName -like "$ExcludeFilter")) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
                                 }
                                 $false {
                                     Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' excluding apps like '{1}'" -f $AppName, $ExcludeFilter) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Where-Object { ( -not ($_.LocalizedDisplayName -like "$ExcludeFilter") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an Application(s) to process the associated deployment types' -OutputMode Single
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Where-Object { ( -not ($_.LocalizedDisplayName -like "$ExcludeFilter") ) } | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an Application(s) to process the associated deployment types' -OutputMode Single
                                 }
                             }
                         }
@@ -107,11 +107,11 @@ function Get-AppList {
                                 $true {
                                     write-host "hank"
                                     Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}' (NoOgv parameter passed)" -f $AppName) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName
                                 }
                                 $false {
                                     Write-LogAndHost -Message ("Invoking Get-CMApplication (fast) including apps like '{0}'" -f $AppName) -LogId $LogId -ForegroundColor Cyan
-                                    $applicationResult = Get-CMApplication -Fast -Name "*$AppName*" | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an application to process the associated deployment types' -OutputMode Single
+                                    $applicationResult = Get-CMApplication -Fast -Name "$AppName" | Select-Object @{ Name = 'Id'; Expression = { $_.CI_ID.toString() } }, LocalizedDisplayName, HasContent, NumberOfDeploymentTypes, IsDeployable, IsDeployed, DateCreated, DateLastModified, LastModifiedBy | Sort-Object LocalizedDisplayName | Out-GridView -Title 'Select an application to process the associated deployment types' -OutputMode Single
                                 }
                             }
                         }

--- a/Private/Write-Log.ps1
+++ b/Private/Write-Log.ps1
@@ -38,7 +38,8 @@ function Write-Log {
         [Parameter(Mandatory = $false, ValueFromPipeline = $true, Position = 1, HelpMessage = 'Location of the log file to write to')]
         [String]$LogFolder = "$workingFolder_Root\Logs", #$workingFolder is defined as a Global parameter in the main script
         [Parameter(Mandatory = $false, ValueFromPipeline = $true, Position = 2, HelpMessage = 'Name of the log file to write to. Main is the default log file')]
-        [String]$Log = 'Main.log',
+        # [String]$Log = 'Main.log',
+        [String]$Log = $global:logFileName,
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, HelpMessage = 'LogId name of the script of the calling function')]
         [String]$LogId = $($MyInvocation.MyCommand).Name,
         [Parameter(Mandatory = $false, ValueFromPipeline = $true, Position = 3, HelpMessage = 'Severity of the log entry 1-3')]

--- a/Public/New-Win32App.ps1
+++ b/Public/New-Win32App.ps1
@@ -150,44 +150,50 @@ function New-Win32App {
         [Switch]$PackageApps,
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 7, HelpMessage = 'ResetLog: Pass this parameter to reset the log file')]
         [Switch]$ResetLog,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 8, HelpMessage = 'ExcludePMPC: Pass this parameter to exclude apps created by PMPC from the results. Filter is applied to Application "Comments". string can be modified in Get-AppList Function')]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 8, HelpMessage = 'The name of the main log file excluing the ".log" extension (Default: "Main.log")')]
+        [string]$logFileName = "Main",
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 9, HelpMessage = 'ExcludePMPC: Pass this parameter to exclude apps created by PMPC from the results. Filter is applied to Application "Comments". string can be modified in Get-AppList Function')]
         [Switch]$ExcludePMPC,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 9, HelpMessage = 'ExcludeFilter: Pass this parameter to exclude specific apps from the results. string value that accepts wildcards e.g. "Microsoft*"')]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 10, HelpMessage = 'ExcludeFilter: Pass this parameter to exclude specific apps from the results. string value that accepts wildcards e.g. "Microsoft*"')]
         [string]$ExcludeFilter,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 10, HelpMessage = 'NoOGV: When passed, the Out-Gridview is suppressed')]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 11, HelpMessage = 'NoOGV: When passed, the Out-Gridview is suppressed')]
         [Switch]$NoOgv,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 11, HelpMessage = 'URI for Win32 Content Prep Tool')]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 12, HelpMessage = 'URI for Win32 Content Prep Tool')]
         [string]$Win32ContentPrepToolUri = 'https://raw.githubusercontent.com/microsoft/Microsoft-Win32-Content-Prep-Tool/refs/heads/master/IntuneWinAppUtil.exe',
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 12, HelpMessage = 'Override intunewin filename. Default is the name calculated from the install command line')]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 13, HelpMessage = 'Override intunewin filename. Default is the name calculated from the install command line')]
         [string]$OverrideIntuneWin32FileName,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 13, HelpMessage = 'Notes field value to add to the Win32App JSON body')]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 14, HelpMessage = 'Notes field value to add to the Win32App JSON body')]
         [string]$Win32AppNotes = "Created by the Win32App Migration Tool",
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 14, HelpMessage = "When creating the Win32App, allow the user to uninstall the app if it is available in the Company Portal")]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 15, HelpMessage = "When creating the Win32App, allow the user to uninstall the app if it is available in the Company Portal")]
         [bool]$AllowAvailableUninstall = $true,
-        [Parameter(Mandatory = $false, Position = 15, HelpMessage = 'CreateApps: Pass this parameter to create the Win32apps in Intune')]
+        [Parameter(Mandatory = $false, Position = 16, HelpMessage = 'CreateApps: Pass this parameter to create the Win32apps in Intune')]
         [Switch]$CreateApps,
+        [Parameter(Mandatory = $false, Position = 17, HelpMessage = 'NoConsoleOutput: Pass this parameter to disable writing to host (output still gets logged)')]
+        [Switch]$NoConsoleOutput,
+        [Parameter(Mandatory = $false, Position = 18, HelpMessage = 'Win32ContentPrepToolSilentMode: Pass this parameter to hide the IntuneWinAppUtil Window')]
+        [Switch]$Win32ContentPrepToolSilentMode,
 
         # Shared Parameters for Graph Authentication
-        [Parameter(Mandatory = $true, ParameterSetName = 'ClientSecret', Position = 16, HelpMessage = 'Tenant Id or name to connect to')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ClientCertificateThumbprint', Position = 16, HelpMessage = 'Tenant Id or name to connect to')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'UseDeviceAuthentication', Position = 16, HelpMessage = 'Tenant Id or name to connect to')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Interactive', Position = 16, HelpMessage = 'Tenant Id or name to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientSecret', Position = 19, HelpMessage = 'Tenant Id or name to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientCertificateThumbprint', Position = 19, HelpMessage = 'Tenant Id or name to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'UseDeviceAuthentication', Position = 19, HelpMessage = 'Tenant Id or name to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Interactive', Position = 19, HelpMessage = 'Tenant Id or name to connect to')]
         [string]$TenantId,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ClientSecret', Position = 17, HelpMessage = 'Client Id (App Registration) to connect to')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ClientCertificateThumbprint', Position = 17, HelpMessage = 'Client Id (App Registration) to connect to')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'UseDeviceAuthentication', Position = 17, HelpMessage = 'Client Id (App Registration) to connect to')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Interactive', Position = 17, HelpMessage = 'Client Id (App Registration) to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientSecret', Position = 20, HelpMessage = 'Client Id (App Registration) to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientCertificateThumbprint', Position = 20, HelpMessage = 'Client Id (App Registration) to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'UseDeviceAuthentication', Position = 20, HelpMessage = 'Client Id (App Registration) to connect to')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Interactive', Position = 20, HelpMessage = 'Client Id (App Registration) to connect to')]
         [string]$ClientId,
 
         # AuthN and AuthZ Parameters
-        [Parameter(Mandatory = $true, ParameterSetName = 'ClientSecret', Position = 18, HelpMessage = 'Client secret for authentication')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientSecret', Position = 21, HelpMessage = 'Client secret for authentication')]
         [string]$ClientSecret,
-        [Parameter(Mandatory = $true, ParameterSetName = 'ClientCertificateThumbprint', Position = 18, HelpMessage = 'Client certificate thumbprint for authentication')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientCertificateThumbprint', Position = 21, HelpMessage = 'Client certificate thumbprint for authentication')]
         [string]$ClientCertificateThumbprint,
-        [Parameter(Mandatory = $true, ParameterSetName = 'UseDeviceAuthentication', Position = 18, HelpMessage = 'Use device authentication for Microsoft Graph API')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'UseDeviceAuthentication', Position = 21, HelpMessage = 'Use device authentication for Microsoft Graph API')]
         [switch]$UseDeviceAuthentication,
-        [Parameter(Mandatory = $false, Position = 19, HelpMessage = 'The scopes required for Microsoft Graph API access')]
+        [Parameter(Mandatory = $false, Position = 22, HelpMessage = 'The scopes required for Microsoft Graph API access')]
         [string[]]$RequiredScopes = ('DeviceManagementApps.ReadWrite.All'),
     
         # Additional Parameters
@@ -213,6 +219,13 @@ function New-Win32App {
         # Create global variable(s) 
         $global:workingFolder_Root = $workingFolder
         $global:scopes = $RequiredScopes
+        $global:logFileName = $("$logFileName.log")
+
+        # Overriding "Write-Host" and "Write-Progress" to disable console output
+        if ($NoConsoleOutput) { 
+            function global:Write-Host(){}
+            function global:Write-Progress(){}
+        }
 
         #region Prepare_Workspace
         # Initialize folders to prepare workspace for logging
@@ -528,6 +541,8 @@ function New-Win32App {
                 if ($OverrideIntuneWin32FileName) { 
                     $paramsToPassIntuneWin.Add('OverrideIntuneWin32FileName', $OverrideIntuneWin32FileName) 
                 }
+
+                $paramsToPassIntuneWin.Add('silentMode', $Win32ContentPrepToolSilentMode)
 
                 # Create the .intunewin file
                 New-IntuneWin @paramsToPassIntuneWin

--- a/Public/New-Win32App.ps1
+++ b/Public/New-Win32App.ps1
@@ -150,7 +150,7 @@ function New-Win32App {
         [Switch]$PackageApps,
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 7, HelpMessage = 'ResetLog: Pass this parameter to reset the log file')]
         [Switch]$ResetLog,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 8, HelpMessage = 'The name of the main log file excluing the ".log" extension (Default: "Main.log")')]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 8, HelpMessage = 'The name of the main log file excluing the ".log" extension (Default: "Main")')]
         [string]$logFileName = "Main",
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, Position = 9, HelpMessage = 'ExcludePMPC: Pass this parameter to exclude apps created by PMPC from the results. Filter is applied to Application "Comments". string can be modified in Get-AppList Function')]
         [Switch]$ExcludePMPC,
@@ -170,7 +170,7 @@ function New-Win32App {
         [Switch]$CreateApps,
         [Parameter(Mandatory = $false, Position = 17, HelpMessage = 'NoConsoleOutput: Pass this parameter to disable writing to host (output still gets logged)')]
         [Switch]$NoConsoleOutput,
-        [Parameter(Mandatory = $false, Position = 18, HelpMessage = 'Win32ContentPrepToolSilentMode: Pass this parameter to hide the IntuneWinAppUtil Window')]
+        [Parameter(Mandatory = $false, Position = 18, HelpMessage = 'Win32ContentPrepToolSilentMode: Pass this parameter to hide the IntuneWinAppUtil Window which is shown when packaging apps')]
         [Switch]$Win32ContentPrepToolSilentMode,
 
         # Shared Parameters for Graph Authentication

--- a/README.md
+++ b/README.md
@@ -294,6 +294,36 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Parameter Win32ContentPrepToolSilentMode
+
+Pass this parameter to hide the IntuneWinAppUtil Window which is shown when packaging apps
+
+```yaml
+Type: Switch
+Parameter Sets: (All)
+
+Required: False
+Position:
+Default value:
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameter NoConsoleOutput
+
+Pass this parameter to disable writing to host (output still gets logged)
+
+```yaml
+Type: Switch
+Parameter Sets: (All)
+
+Required: False
+Position:
+Default value:
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Parameter CreateApps
 
 Pass this parameter to create the Win32apps in Intune
@@ -319,6 +349,21 @@ Parameter Sets: (All)
 
 Required: False
 Position:
+Default value:
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameter logFileName
+
+The name of the main log file excluing the ".log" extension (Default: "Main") - Useful when running multiple instances of New-Win32App in the same working directory, so a seperate log file is generated for each instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: False
+Position: 
 Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -465,6 +510,9 @@ New-Win32App -ProviderMachineName "SCCM1.byteben.com" -AppName "Microsoft Edge C
   ```
   ```
 New-Win32App -ProviderMachineName "SCCM1.byteben.com" -AppName "Microsoft Edge Chromium *" -ExportLogo -PackageApps -ResetLog  
+  ```
+  ```
+New-Win32App -ProviderMachineName "SCCM1.byteben.com" -AppName "Microsoft Edge Chromium *" -ExportLogo -PackageApps -ResetLog -logFileName "Microsoft Edge Export"
   ```
   ```
 New-Win32App -ProviderMachineName "SCCM1.byteben.com" -AppName "Microsoft Edge Chromium *" -ExportLogo -PackageApps -ResetLog -NoOGV  


### PR DESCRIPTION
- **Fixed Wilcard bug** - Removed wildcards surrounding $appName from Get-AppList, because previously, even without wildcards, it would return every app containing the same string which causes issues when -NoOGV is specified, since it would target all apps containing the $appName with no way to filter it. (Users can still add * to -AppName if they want to use wildcards)

- **Fixed ExcludePMPC bug** - In Get-AppList the Get-CMApplication cmdlets were using $Pmpc_Comment (undefined) instead of $PmpcComment so when $ExcludePMPC was true, it would return nothing since it omits results containing '' (everything)

- **Added "-logFileName" parameter** (defaults to 'Main.log') to New-Win32App to give the user the option to specify a custom log file name - When running multiple instances of the New-Win32App in the same working directory, it attempts to write to Main.log in parallel, causing all instances to throw a file in use error. This parameter is useful for creating different log files for each instance of the migration tool.

- **Added "-NoConsoleOutput" switch** to New-Win32App - When specified it overrides Write-Host and Write-Progress to do nothing, still writes to a log file but does not show in console output

- **Added -Win32ContentPrepToolSilentMode switch** to New-Win32App, when specified it appends "WindowStyle:Hidden" to Start-Process which runs IntuneWinAppUtil without opening a window - Since I was running a multi-threaded script, without this it would flood my screen with IntuneWinAppUtil windows while packaging apps

- **Added .msp handing** in New-IntuneWin - Previously when building a intunewin file using a .msp installer, if it contained "msiexec.exe" (eg: msiexec.exe /p "example.msp" /qn) it would attempt to pass msiexec.exe into the IntuneWinAppUtil or if the install command contained just msiexec (eg: msiexec /p "example.msp" /qn) it would fail at "No matching extension found."